### PR TITLE
Annotate all module generating annotations with @GeneratesRootInput

### DIFF
--- a/android/testing/build.gradle.kts
+++ b/android/testing/build.gradle.kts
@@ -5,5 +5,6 @@ plugins {
 }
 
 dependencies {
+    implementation(libs.dagger.hilt.core)
     api(projects.core)
 }

--- a/android/testing/src/main/kotlin/se/ansman/dagger/auto/android/testing/Replaces.kt
+++ b/android/testing/src/main/kotlin/se/ansman/dagger/auto/android/testing/Replaces.kt
@@ -1,5 +1,6 @@
 package se.ansman.dagger.auto.android.testing
 
+import dagger.hilt.GeneratesRootInput
 import se.ansman.dagger.auto.AutoBind
 import se.ansman.dagger.auto.AutoBindIntoMap
 import se.ansman.dagger.auto.AutoBindIntoSet
@@ -65,6 +66,7 @@ import kotlin.reflect.KClass
  */
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.CLASS)
+@GeneratesRootInput
 annotation class Replaces(
     val type: KClass<*>,
 )

--- a/core/src/main/kotlin/se/ansman/dagger/auto/AutoBind.kt
+++ b/core/src/main/kotlin/se/ansman/dagger/auto/AutoBind.kt
@@ -1,5 +1,6 @@
 package se.ansman.dagger.auto
 
+import dagger.hilt.GeneratesRootInput
 import javax.inject.Qualifier
 import kotlin.reflect.KClass
 
@@ -91,6 +92,7 @@ import kotlin.reflect.KClass
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
+@GeneratesRootInput
 public annotation class AutoBind(
     val inComponent: KClass<*> = Nothing::class,
     val asTypes: Array<KClass<*>> = [],

--- a/core/src/main/kotlin/se/ansman/dagger/auto/AutoBindIntoMap.kt
+++ b/core/src/main/kotlin/se/ansman/dagger/auto/AutoBindIntoMap.kt
@@ -1,6 +1,7 @@
 package se.ansman.dagger.auto
 
 import dagger.MapKey
+import dagger.hilt.GeneratesRootInput
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import kotlin.reflect.KClass
@@ -26,6 +27,7 @@ import kotlin.reflect.KClass
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
+@GeneratesRootInput
 public annotation class AutoBindIntoMap(
     val inComponent: KClass<*> = Nothing::class,
     val asTypes: Array<KClass<*>> = [],

--- a/core/src/main/kotlin/se/ansman/dagger/auto/AutoBindIntoSet.kt
+++ b/core/src/main/kotlin/se/ansman/dagger/auto/AutoBindIntoSet.kt
@@ -1,5 +1,6 @@
 package se.ansman.dagger.auto
 
+import dagger.hilt.GeneratesRootInput
 import dagger.multibindings.IntoSet
 import kotlin.reflect.KClass
 
@@ -21,6 +22,7 @@ import kotlin.reflect.KClass
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
+@GeneratesRootInput
 public annotation class AutoBindIntoSet(
     val inComponent: KClass<*> = Nothing::class,
     val asTypes: Array<KClass<*>> = [],

--- a/core/src/main/kotlin/se/ansman/dagger/auto/AutoInitialize.kt
+++ b/core/src/main/kotlin/se/ansman/dagger/auto/AutoInitialize.kt
@@ -1,5 +1,7 @@
 package se.ansman.dagger.auto
 
+import dagger.hilt.GeneratesRootInput
+
 /**
  * Marks the given objects as being initializable.
  *
@@ -23,6 +25,7 @@ package se.ansman.dagger.auto
     AnnotationTarget.FUNCTION,
     AnnotationTarget.PROPERTY_GETTER,
 )
+@GeneratesRootInput
 public annotation class AutoInitialize(
     val priority: Int = defaultPriority
 ) {


### PR DESCRIPTION
This is required in order for Hilt to correctly generate components.

This fixes #71