### PR TITLE
Fix the package name of AutoProvideDaos and the ViewModel code

### DIFF
--- a/androidx/room/api/room.api
+++ b/androidx/room/api/room.api
@@ -1,4 +1,4 @@
-public abstract interface annotation class co/ansman/dagger/auto/androidx/room/AutoProvideDaos : java/lang/annotation/Annotation {
+public abstract interface annotation class se/ansman/dagger/auto/androidx/room/AutoProvideDaos : java/lang/annotation/Annotation {
 	public abstract fun inComponent ()Ljava/lang/Class;
 }
 

--- a/androidx/room/src/main/kotlin/co/ansman/dagger/auto/androidx/room/AutoProvideDaos.kt
+++ b/androidx/room/src/main/kotlin/co/ansman/dagger/auto/androidx/room/AutoProvideDaos.kt
@@ -1,50 +1,8 @@
 package co.ansman.dagger.auto.androidx.room
 
-import dagger.hilt.GeneratesRootInput
-import dagger.hilt.components.SingletonComponent
-import kotlin.reflect.KClass
-
-/**
- * A marker for [Room Databases](https://developer.android.com/training/data-storage/room) that will automatically
- * contribute all DAOs in your database to the dependency graph.
- *
- * Simply add this annotation to a Database and auto-data will provide all DAOs.
- *
- * Example:
- * ```
- * @AutoProvideDaos
- * @Database(entities = [User::class], version = 1)
- * abstract class AppDatabase : RoomDatabase() {
- *     abstract fun userDao(): UserDao
- * }
- *
- * // You'll also need to provide the Database instance to the component you want to inject the service into:
- * @Module
- * @InstallIn(SingletonComponent::class)
- * object DatabaseModule {
- *   @Provides
- *   @Singleton
- *   fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
- *     Room.databaseBuilder(context, AppDatabase::class.java, "database-name").build()
- * }
- * ```
- *
- * ## Changing the target component
- * By default, the DAOs are provided in the [SingletonComponent]. If you'd like to change this you can do so by
- * specifying the `inComponent` parameter:
- * ```
- * @AutoProvideDaos
- * @Database(entities = [User::class], version = 1)
- * abstract class AppDatabase : RoomDatabase() {
- *   abstract fun userDao(): UserDao
- * }
- * ```
- *
- * @param inComponent The component to provide the DAOs in. Defaults to [SingletonComponent].
- */
-@Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.BINARY)
-@GeneratesRootInput
-public annotation class AutoProvideDaos(
-    val inComponent: KClass<*> = SingletonComponent::class,
+@Deprecated(
+    message = "This annotation was incorrectly added to the wrong package. Use se.ansman.dagger.auto.androidx.room.AutoProvideDaos instead.",
+    replaceWith = ReplaceWith("AutoProvideDaos", "se.ansman.dagger.auto.androidx.room.AutoProvideDaos"),
+    level = DeprecationLevel.ERROR,
 )
+public typealias AutoProvideDaos = se.ansman.dagger.auto.androidx.room.AutoProvideDaos

--- a/androidx/room/src/main/kotlin/se/ansman/dagger/auto/androidx/room/AutoProvideDaos.kt
+++ b/androidx/room/src/main/kotlin/se/ansman/dagger/auto/androidx/room/AutoProvideDaos.kt
@@ -1,0 +1,50 @@
+package se.ansman.dagger.auto.androidx.room
+
+import dagger.hilt.GeneratesRootInput
+import dagger.hilt.components.SingletonComponent
+import kotlin.reflect.KClass
+
+/**
+ * A marker for [Room Databases](https://developer.android.com/training/data-storage/room) that will automatically
+ * contribute all DAOs in your database to the dependency graph.
+ *
+ * Simply add this annotation to a Database and auto-data will provide all DAOs.
+ *
+ * Example:
+ * ```
+ * @AutoProvideDaos
+ * @Database(entities = [User::class], version = 1)
+ * abstract class AppDatabase : RoomDatabase() {
+ *     abstract fun userDao(): UserDao
+ * }
+ *
+ * // You'll also need to provide the Database instance to the component you want to inject the service into:
+ * @Module
+ * @InstallIn(SingletonComponent::class)
+ * object DatabaseModule {
+ *   @Provides
+ *   @Singleton
+ *   fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
+ *     Room.databaseBuilder(context, AppDatabase::class.java, "database-name").build()
+ * }
+ * ```
+ *
+ * ## Changing the target component
+ * By default, the DAOs are provided in the [SingletonComponent]. If you'd like to change this you can do so by
+ * specifying the `inComponent` parameter:
+ * ```
+ * @AutoProvideDaos
+ * @Database(entities = [User::class], version = 1)
+ * abstract class AppDatabase : RoomDatabase() {
+ *   abstract fun userDao(): UserDao
+ * }
+ * ```
+ *
+ * @param inComponent The component to provide the DAOs in. Defaults to [SingletonComponent].
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+@GeneratesRootInput
+public annotation class AutoProvideDaos(
+    val inComponent: KClass<*> = SingletonComponent::class,
+)

--- a/androidx/viewmodel/api/viewmodel.api
+++ b/androidx/viewmodel/api/viewmodel.api
@@ -1,16 +1,16 @@
-public final class co/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponent {
-	public static final field INSTANCE Lco/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponent;
+public final class se/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponent {
+	public static final field INSTANCE Lse/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponent;
 	public final fun provideViewModelScope (Ldagger/hilt/android/ViewModelLifecycle;)Lkotlinx/coroutines/CoroutineScope;
 }
 
-public final class co/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponent_ProvideViewModelScopeFactory : dagger/internal/Factory {
+public final class se/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponent_ProvideViewModelScopeFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;)Lco/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponent_ProvideViewModelScopeFactory;
+	public static fun create (Ljavax/inject/Provider;)Lse/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponent_ProvideViewModelScopeFactory;
 	public synthetic fun get ()Ljava/lang/Object;
 	public fun get ()Lkotlinx/coroutines/CoroutineScope;
 	public static fun provideViewModelScope (Ldagger/hilt/android/ViewModelLifecycle;)Lkotlinx/coroutines/CoroutineScope;
 }
 
-public abstract interface annotation class co/ansman/dagger/auto/androidx/viewmodel/ViewModelSpecific : java/lang/annotation/Annotation {
+public abstract interface annotation class se/ansman/dagger/auto/androidx/viewmodel/ViewModelSpecific : java/lang/annotation/Annotation {
 }
 

--- a/androidx/viewmodel/src/main/kotlin/co/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponent.kt
+++ b/androidx/viewmodel/src/main/kotlin/co/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponent.kt
@@ -1,49 +1,8 @@
 package co.ansman.dagger.auto.androidx.viewmodel
 
-import androidx.lifecycle.ViewModel
-import dagger.Module
-import dagger.Provides
-import dagger.hilt.InstallIn
-import dagger.hilt.android.ViewModelLifecycle
-import dagger.hilt.android.components.ViewModelComponent
-import dagger.hilt.android.lifecycle.RetainedLifecycle
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlin.coroutines.CoroutineContext
-
-/**
- * A Dagger module which provides a [CoroutineScope] that is tied to the lifecycle of a [ViewModel].
- *
- * The provided scope is qualified with [ViewModelSpecific] and will be canceled when the viewmodel is cleared and it
- * ses a [SupervisorJob] and the `[Dispatchers].Main.immediate` dispatcher.
- *
- * To inject:
- * ```
- * @HiltViewModel
- * class MyViewModel @Inject constructor(
- *   @ViewModelSpecific
- *   private val viewModelScope: CoroutineScope
- * ) : ViewModel()
- * ```
- */
-@Module
-@InstallIn(ViewModelComponent::class)
-object AutoDaggerViewModelCoroutineScopeComponent {
-    @Provides
-    @ViewModelSpecific
-    fun provideViewModelScope(lifecycle: ViewModelLifecycle): CoroutineScope =
-        ClearableCoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-            .also(lifecycle::addOnClearedListener)
-}
-
-
-private class ClearableCoroutineScope(
-    override val coroutineContext: CoroutineContext
-) : CoroutineScope, RetainedLifecycle.OnClearedListener {
-
-    override fun onCleared() {
-        coroutineContext.cancel()
-    }
-}
+@Deprecated(
+    message = "This module was incorrectly added to the wrong package. Use se.ansman.dagger.auto.androidx.viewmodel.AutoDaggerViewModelCoroutineScopeComponent instead.",
+    replaceWith = ReplaceWith("AutoDaggerViewModelCoroutineScopeComponent", "se.ansman.dagger.auto.androidx.viewmodel.AutoDaggerViewModelCoroutineScopeComponent"),
+    level = DeprecationLevel.ERROR,
+)
+typealias AutoDaggerViewModelCoroutineScopeComponent = se.ansman.dagger.auto.androidx.viewmodel.AutoDaggerViewModelCoroutineScopeComponent

--- a/androidx/viewmodel/src/main/kotlin/co/ansman/dagger/auto/androidx/viewmodel/ViewModelSpecific.kt
+++ b/androidx/viewmodel/src/main/kotlin/co/ansman/dagger/auto/androidx/viewmodel/ViewModelSpecific.kt
@@ -1,29 +1,8 @@
 package co.ansman.dagger.auto.androidx.viewmodel
 
-import dagger.hilt.android.components.ViewModelComponent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import javax.inject.Qualifier
-
-/**
- * A qualifier indicating that the annotated type is tied to [ViewModelComponent].
- *
- * By default the following things are automatically provided:
- * ## CoroutineScope
- * A [CoroutineScope] that is tied to the view model's lifecycle is contributed. The scope uses a [SupervisorJob] and
- * the `[Dispatchers].Main.immediate` dispatcher.
- *
- * To use it simply inject it like this:
- * ```
- * @HiltViewMode
- * class MyViewModel @Inject constructor(
- *   @ViewModelSpecific
- *   private val viewModelScope: CoroutineScope
- * ) : ViewModel()
- * ```
- */
-@MustBeDocumented
-@Retention(AnnotationRetention.BINARY)
-@Qualifier
-annotation class ViewModelSpecific
+@Deprecated(
+    message = "This annotation was incorrectly added to the wrong package. Use se.ansman.dagger.auto.androidx.viewmodel.ViewModelSpecific instead.",
+    replaceWith = ReplaceWith("ViewModelSpecific", "se.ansman.dagger.auto.androidx.viewmodel.ViewModelSpecific"),
+    level = DeprecationLevel.ERROR,
+)
+typealias ViewModelSpecific = se.ansman.dagger.auto.androidx.viewmodel.ViewModelSpecific

--- a/androidx/viewmodel/src/main/kotlin/se/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponent.kt
+++ b/androidx/viewmodel/src/main/kotlin/se/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponent.kt
@@ -1,0 +1,48 @@
+package se.ansman.dagger.auto.androidx.viewmodel
+
+import androidx.lifecycle.ViewModel
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.ViewModelLifecycle
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.lifecycle.RetainedLifecycle
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A Dagger module which provides a [CoroutineScope] that is tied to the lifecycle of a [ViewModel].
+ *
+ * The provided scope is qualified with [ViewModelSpecific] and will be canceled when the viewmodel is cleared and it
+ * ses a [SupervisorJob] and the `[Dispatchers].Main.immediate` dispatcher.
+ *
+ * To inject:
+ * ```
+ * @HiltViewModel
+ * class MyViewModel @Inject constructor(
+ *   @ViewModelSpecific
+ *   private val viewModelScope: CoroutineScope
+ * ) : ViewModel()
+ * ```
+ */
+@Module
+@InstallIn(ViewModelComponent::class)
+object AutoDaggerViewModelCoroutineScopeComponent {
+    @Provides
+    @ViewModelSpecific
+    fun provideViewModelScope(lifecycle: ViewModelLifecycle): CoroutineScope =
+        ClearableCoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+            .also(lifecycle::addOnClearedListener)
+}
+
+private class ClearableCoroutineScope(
+    override val coroutineContext: CoroutineContext
+) : CoroutineScope, RetainedLifecycle.OnClearedListener {
+
+    override fun onCleared() {
+        coroutineContext.cancel()
+    }
+}

--- a/androidx/viewmodel/src/main/kotlin/se/ansman/dagger/auto/androidx/viewmodel/ViewModelSpecific.kt
+++ b/androidx/viewmodel/src/main/kotlin/se/ansman/dagger/auto/androidx/viewmodel/ViewModelSpecific.kt
@@ -1,0 +1,30 @@
+package se.ansman.dagger.auto.androidx.viewmodel
+
+import dagger.hilt.android.components.ViewModelComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Qualifier
+
+
+/**
+ * A qualifier indicating that the annotated type is tied to [ViewModelComponent].
+ *
+ * By default the following things are automatically provided:
+ * ## CoroutineScope
+ * A [CoroutineScope] that is tied to the view model's lifecycle is contributed. The scope uses a [SupervisorJob] and
+ * the `[Dispatchers].Main.immediate` dispatcher.
+ *
+ * To use it simply inject it like this:
+ * ```
+ * @HiltViewMode
+ * class MyViewModel @Inject constructor(
+ *   @ViewModelSpecific
+ *   private val viewModelScope: CoroutineScope
+ * ) : ViewModel()
+ * ```
+ */
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class ViewModelSpecific

--- a/androidx/viewmodel/src/test/kotlin/se/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponentTest.kt
+++ b/androidx/viewmodel/src/test/kotlin/se/ansman/dagger/auto/androidx/viewmodel/AutoDaggerViewModelCoroutineScopeComponentTest.kt
@@ -1,4 +1,4 @@
-package co.ansman.dagger.auto.androidx.viewmodel
+package se.ansman.dagger.auto.androidx.viewmodel
 
 import assertk.assertThat
 import assertk.assertions.isFalse

--- a/compiler/common/src/main/kotlin/se/ansman/dagger/auto/compiler/common/ksp/KSAnnotations.kt
+++ b/compiler/common/src/main/kotlin/se/ansman/dagger/auto/compiler/common/ksp/KSAnnotations.kt
@@ -6,12 +6,12 @@ import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSName
 import com.google.devtools.ksp.symbol.KSType
-import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.ksp.toClassName
 import se.ansman.dagger.auto.compiler.common.applyEachIndexed
+import se.ansman.dagger.auto.compiler.common.ksp.processing.unwrapTypeAlias
 import java.util.Locale
 
 /**
@@ -39,8 +39,6 @@ fun KSAnnotation.toAnnotationSpecFixed(): AnnotationSpec =
             )
         }
         .build()
-
-fun KSType.unwrapTypeAlias(): KSType = (declaration as? KSTypeAlias)?.type?.resolve() ?: this
 
 private fun CodeBlock.Builder.addAnnotationValue(value: Any): CodeBlock.Builder =
     when (value) {

--- a/compiler/common/src/main/kotlin/se/ansman/dagger/auto/compiler/common/ksp/processing/KSDeclarations.kt
+++ b/compiler/common/src/main/kotlin/se/ansman/dagger/auto/compiler/common/ksp/processing/KSDeclarations.kt
@@ -2,7 +2,6 @@ package se.ansman.dagger.auto.compiler.common.ksp.processing
 
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
-import se.ansman.dagger.auto.compiler.common.ksp.unwrapTypeAlias
 
 fun KSType.unwrapTypeAlias(): KSType =
     (declaration as? KSTypeAlias)?.type?.resolve()?.unwrapTypeAlias() ?: this

--- a/compiler/common/src/main/kotlin/se/ansman/dagger/auto/compiler/common/ksp/processing/KspAnnotationModel.kt
+++ b/compiler/common/src/main/kotlin/se/ansman/dagger/auto/compiler/common/ksp/processing/KspAnnotationModel.kt
@@ -18,7 +18,9 @@ class KspAnnotationModel(
     private val resolver: KspResolver,
 ) : AnnotationModel<ClassName, AnnotationSpec> {
     override val className by lazy(LazyThreadSafetyMode.NONE) {
-        annotation.annotationType.resolve().toClassName()
+        annotation.annotationType.resolve()
+            .unwrapTypeAlias()
+            .toClassName()
     }
 
     override val qualifiedName: String

--- a/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/androidx/room/AndroidXRoomProcessor.kt
+++ b/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/androidx/room/AndroidXRoomProcessor.kt
@@ -1,6 +1,6 @@
 package se.ansman.dagger.auto.compiler.androidx.room
 
-import co.ansman.dagger.auto.androidx.room.AutoProvideDaos
+import se.ansman.dagger.auto.androidx.room.AutoProvideDaos
 import dagger.hilt.components.SingletonComponent
 import se.ansman.dagger.auto.compiler.Errors
 import se.ansman.dagger.auto.compiler.androidx.room.models.AndroidXRoomDatabaseModule

--- a/compiler/src/test/kotlin/se/ansman/dagger/auto/compiler/AndroidXRoomTest.kt
+++ b/compiler/src/test/kotlin/se/ansman/dagger/auto/compiler/AndroidXRoomTest.kt
@@ -16,7 +16,7 @@ class AndroidXRoomTest {
         compilationFactory.create(tempDirectory)
             .compile(
                 """
-                package co.ansman.dagger.auto.androidx.room
+                package se.ansman.dagger.auto.androidx.room
 
                 interface UserDao
 
@@ -35,7 +35,7 @@ class AndroidXRoomTest {
         compilationFactory.create(tempDirectory)
             .compile(
                 """
-                package co.ansman.dagger.auto.androidx.room
+                package se.ansman.dagger.auto.androidx.room
 
                 interface UserDao
 
@@ -55,7 +55,7 @@ class AndroidXRoomTest {
         compilationFactory.create(tempDirectory)
             .compile(
                 """
-                package co.ansman.dagger.auto.androidx.room
+                package se.ansman.dagger.auto.androidx.room
 
                 interface UserDao
 
@@ -69,5 +69,27 @@ class AndroidXRoomTest {
                 """
             )
             .assertFailedWithMessage(Errors.AndroidX.Room.typeMustDirectlyExtendRoomDatabase)
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(AutoDaggerCompilationFactoryProvider::class)
+    fun `the legacy annotation works`(compilationFactory: Compilation.Factory) {
+        compilationFactory.create(tempDirectory)
+            .compile(
+                """
+                package co.ansman.dagger.auto.androidx.room
+
+                interface UserDao
+
+                @androidx.room.Database(entities = [], version = 1)
+                @Suppress("DEPRECATION_ERROR")
+                @AutoProvideDaos
+                abstract class AppDatabase : androidx.room.RoomDatabase() {
+                    abstract val users: UserDao
+                }
+                """
+            )
+            .assertIsSuccessful()
+            .assertGeneratedFileNamed("AutoDaggerAppDatabaseModule")
     }
 }

--- a/compiler/src/test/resources/tests/androidx_room/duplicate_accessors/AppDatabase.kt
+++ b/compiler/src/test/resources/tests/androidx_room/duplicate_accessors/AppDatabase.kt
@@ -2,7 +2,7 @@ package tests.androidx_room.duplicate_accessors
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import co.ansman.dagger.auto.androidx.room.AutoProvideDaos
+import se.ansman.dagger.auto.androidx.room.AutoProvideDaos
 
 interface UserDao
 

--- a/compiler/src/test/resources/tests/androidx_room/functions/AppDatabase.kt
+++ b/compiler/src/test/resources/tests/androidx_room/functions/AppDatabase.kt
@@ -2,7 +2,7 @@ package tests.androidx_room.functions
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import co.ansman.dagger.auto.androidx.room.AutoProvideDaos
+import se.ansman.dagger.auto.androidx.room.AutoProvideDaos
 
 interface UserDao
 

--- a/compiler/src/test/resources/tests/androidx_room/properties/AppDatabase.kt
+++ b/compiler/src/test/resources/tests/androidx_room/properties/AppDatabase.kt
@@ -2,7 +2,7 @@ package tests.androidx_room.properties
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import co.ansman.dagger.auto.androidx.room.AutoProvideDaos
+import se.ansman.dagger.auto.androidx.room.AutoProvideDaos
 
 interface UserDao
 interface BookDao

--- a/tests/src/main/kotlin/se/ansman/dagger/auto/androidx/room/AppDatabase.kt
+++ b/tests/src/main/kotlin/se/ansman/dagger/auto/androidx/room/AppDatabase.kt
@@ -6,7 +6,6 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.Query
 import androidx.room.RoomDatabase
-import co.ansman.dagger.auto.androidx.room.AutoProvideDaos
 
 @Entity("users")
 data class User(@PrimaryKey val id: String, val name: String)

--- a/tests/src/main/kotlin/se/ansman/dagger/auto/androidx/viewmodel/ExampleViewModel.kt
+++ b/tests/src/main/kotlin/se/ansman/dagger/auto/androidx/viewmodel/ExampleViewModel.kt
@@ -1,7 +1,6 @@
 package se.ansman.dagger.auto.androidx.viewmodel
 
 import androidx.lifecycle.ViewModel
-import co.ansman.dagger.auto.androidx.viewmodel.ViewModelSpecific
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject


### PR DESCRIPTION
The package name had incorrectly been set as `co.ansman.dagger.auto` instead of `se.ansman.dagger.auto`. The relevant code has moved and typealiases have been left with error severity. These typealiases will be removed in the next version.