### PR TITLE
Remove the shadowjar archive classifier

### DIFF
--- a/compiler/common/build.gradle.kts
+++ b/compiler/common/build.gradle.kts
@@ -14,7 +14,6 @@ configurations.named("compileOnly") { extendsFrom(compileShaded) }
 configurations.named("testRuntimeOnly") { extendsFrom(compileShaded) }
 
 val shadowJar = tasks.named<ShadowJar>("shadowJar") {
-    archiveClassifier.set("")
     configurations = listOf(compileShaded)
     isEnableRelocation = true
     relocationPrefix = "se.ansman.dagger.auto${project.path.replace(':', '.').replace('-', '_')}"


### PR DESCRIPTION
It would cause conflicting coordinates with the regular jar.