### PR TITLE
Use a fixed license url when publishing to Maven

### DIFF
--- a/gradle-plugin/src/main/kotlin/library.publishing.gradle.kts
+++ b/gradle-plugin/src/main/kotlin/library.publishing.gradle.kts
@@ -129,7 +129,7 @@ val publication = publishing.publications.register<MavenPublication>("autoDagger
         licenses {
             license {
                 name.set("The Apache Software License, Version 2.0")
-                url.set(remoteSource.map { "$it/LICENSE.txt" })
+                url.set("https://raw.githubusercontent.com/ansman/auto-dagger/main/LICENSE.txt")
                 distribution.set("repo")
             }
         }


### PR DESCRIPTION
When using the [Licensee](https://github.com/cashapp/licensee) Gradle plugin to valide open source licenses, the configuration requires to provide a URL to the license : 
`configure<LicenseeExtension> {
            allowUrl("https://github.com/ansman/auto-dagger/blob/1.2.1/LICENSE.txt")
    }
`
The problem with the current configuration is that the validation will fail every time auto-dagger is updated and will require to update Licensee configuration.
I updated Maven configuration to use a fixed url, like [apollo-kotlin](https://github.com/apollographql/apollo-kotlin/blob/main/gradle.properties#L11).