### PR TITLE
Add `@Generated` to all generated classes

### DIFF
--- a/compiler/common/src/main/kotlin/se/ansman/dagger/auto/compiler/common/models/HiltModule.kt
+++ b/compiler/common/src/main/kotlin/se/ansman/dagger/auto/compiler/common/models/HiltModule.kt
@@ -1,8 +1,10 @@
 package se.ansman.dagger.auto.compiler.common.models
 
+import se.ansman.dagger.auto.compiler.common.Processor
 import se.ansman.dagger.auto.compiler.common.rendering.HiltModuleBuilder
 
 interface HiltModule<out Node, ClassName> {
+    val processor: Class<out Processor<*, *, *, *>>
     val moduleName: ClassName
     val installation: HiltModuleBuilder.Installation<ClassName>
     val originatingTopLevelClassName: ClassName

--- a/compiler/common/src/main/kotlin/se/ansman/dagger/auto/compiler/common/rendering/HiltJavaModuleBuilder.kt
+++ b/compiler/common/src/main/kotlin/se/ansman/dagger/auto/compiler/common/rendering/HiltJavaModuleBuilder.kt
@@ -1,15 +1,6 @@
 package se.ansman.dagger.auto.compiler.common.rendering
 
-import com.squareup.javapoet.AnnotationSpec
-import com.squareup.javapoet.ClassName
-import com.squareup.javapoet.CodeBlock
-import com.squareup.javapoet.JavaFile
-import com.squareup.javapoet.MethodSpec
-import com.squareup.javapoet.NameAllocator
-import com.squareup.javapoet.ParameterSpec
-import com.squareup.javapoet.ParameterizedTypeName
-import com.squareup.javapoet.TypeName
-import com.squareup.javapoet.TypeSpec
+import com.squareup.javapoet.*
 import dagger.Binds
 import dagger.BindsOptionalOf
 import dagger.Module
@@ -21,6 +12,7 @@ import se.ansman.dagger.auto.compiler.common.generatedFileComment
 import se.ansman.dagger.auto.compiler.common.models.HiltModule
 import se.ansman.dagger.auto.compiler.common.rawType
 import se.ansman.dagger.auto.compiler.common.rendering.HiltModuleBuilder.ProviderMode
+import javax.annotation.processing.Generated
 import javax.lang.model.element.Element
 import javax.lang.model.element.Modifier
 
@@ -36,6 +28,9 @@ class HiltJavaModuleBuilder private constructor(
                 .addModifiers(Modifier.PRIVATE)
                 .build()
         )
+        .addAnnotation(AnnotationSpec.builder(Generated::class.java)
+            .addMember("value", "\$S", info.processor.name)
+            .build())
         .addAnnotation(Module::class.java)
         .addAnnotation(
             when (val installation = info.installation) {

--- a/compiler/common/src/main/kotlin/se/ansman/dagger/auto/compiler/common/rendering/HiltKotlinModuleBuilder.kt
+++ b/compiler/common/src/main/kotlin/se/ansman/dagger/auto/compiler/common/rendering/HiltKotlinModuleBuilder.kt
@@ -1,19 +1,8 @@
 package se.ansman.dagger.auto.compiler.common.rendering
 
 import com.google.devtools.ksp.symbol.KSDeclaration
-import com.squareup.kotlinpoet.AnnotationSpec
-import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.CodeBlock
-import com.squareup.kotlinpoet.DelicateKotlinPoetApi
-import com.squareup.kotlinpoet.FileSpec
-import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.NameAllocator
-import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import com.squareup.kotlinpoet.TypeName
-import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
 import dagger.Binds
 import dagger.BindsOptionalOf
@@ -28,6 +17,7 @@ import se.ansman.dagger.auto.compiler.common.ksp.addMemberClassArray
 import se.ansman.dagger.auto.compiler.common.models.HiltModule
 import se.ansman.dagger.auto.compiler.common.rawType
 import se.ansman.dagger.auto.compiler.common.rendering.HiltModuleBuilder.ProviderMode
+import javax.annotation.processing.Generated
 import kotlin.reflect.KClass
 
 class HiltKotlinModuleBuilder private constructor(
@@ -131,6 +121,9 @@ class HiltKotlinModuleBuilder private constructor(
 
         typeSpec
             .apply { info.originatingElement.containingFile?.let(::addOriginatingKSFile) }
+            .addAnnotation(AnnotationSpec.builder(Generated::class)
+                .addMember("%S", info.processor.name)
+                .build())
             .addAnnotation(Module::class)
             .addAnnotation(when (val installation = info.installation) {
                 is HiltModuleBuilder.Installation.InstallIn ->

--- a/compiler/common/test-utils/src/main/kotlin/se/ansman/dagger/auto/compiler/common/testutils/ResourceBasedTestGenerator.kt
+++ b/compiler/common/test-utils/src/main/kotlin/se/ansman/dagger/auto/compiler/common/testutils/ResourceBasedTestGenerator.kt
@@ -16,7 +16,9 @@ import kotlin.streams.asSequence
 class ResourceBasedTestGenerator(
     private val compilationFactoryProvider: CompilationFactoryProvider,
 ) {
-    private val writeExpectedFilesTo = System.getProperty("writeExpectedFilesTo")?.let(::File)
+    private val writeExpectedFilesTo = System.getProperty("writeExpectedFilesTo")
+        ?.takeIf { System.getProperty("writeExpectedFiles")?.toBooleanStrict() ?: false }
+        ?.let(::File)
 
     fun generateTests(tempDirectory: File): Iterable<DynamicNode> =
         Files.list(ClassLoader.getSystemResource("tests").toURI().toPath())

--- a/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/androidx/room/AndroidXRoomProcessor.kt
+++ b/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/androidx/room/AndroidXRoomProcessor.kt
@@ -35,6 +35,7 @@ class AndroidXRoomProcessor<N, TypeName, ClassName : TypeName, AnnotationSpec, F
                 validateComponent(database, resolver, targetComponent)
 
                 AndroidXRoomDatabaseModule(
+                    processor = javaClass,
                     moduleName = environment.rootPeerClass(
                         database.className,
                         environment.simpleNames(database.className).joinToString(

--- a/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/androidx/room/models/AndroidXRoomDatabaseModule.kt
+++ b/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/androidx/room/models/AndroidXRoomDatabaseModule.kt
@@ -1,9 +1,11 @@
 package se.ansman.dagger.auto.compiler.androidx.room.models
 
+import se.ansman.dagger.auto.compiler.common.Processor
 import se.ansman.dagger.auto.compiler.common.models.HiltModule
 import se.ansman.dagger.auto.compiler.common.rendering.HiltModuleBuilder
 
 data class AndroidXRoomDatabaseModule<Node, TypeName, ClassName : TypeName>(
+    override val processor: Class<out Processor<*, *, *, *>>,
     override val moduleName: ClassName,
     override val installation: HiltModuleBuilder.Installation<ClassName>,
     override val originatingTopLevelClassName: ClassName,

--- a/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/autobind/AutoBindProcessor.kt
+++ b/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/autobind/AutoBindProcessor.kt
@@ -196,6 +196,7 @@ class AutoBindProcessor<N, TypeName : Any, ClassName : TypeName, AnnotationSpec,
         output[key] = output[key]
             ?.withTypesAdded(boundTypes)
             ?: AutoBindObjectModule(
+                processor = javaClass,
                 moduleName = getModuleName(type, component),
                 installation = HiltModuleBuilder.Installation.InstallIn(component),
                 originatingTopLevelClassName = environment.topLevelClassName(type.className),

--- a/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/autobind/models/AutoBindObjectModule.kt
+++ b/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/autobind/models/AutoBindObjectModule.kt
@@ -1,9 +1,11 @@
 package se.ansman.dagger.auto.compiler.autobind.models
 
+import se.ansman.dagger.auto.compiler.common.Processor
 import se.ansman.dagger.auto.compiler.common.models.HiltModule
 import se.ansman.dagger.auto.compiler.common.rendering.HiltModuleBuilder
 
 data class AutoBindObjectModule<out Node, TypeName, ClassName : TypeName, AnnotationSpec>(
+    override val processor: Class<out Processor<*, *, *, *>>,
     override val moduleName: ClassName,
     override val installation: HiltModuleBuilder.Installation<ClassName>,
     override val originatingTopLevelClassName: ClassName,

--- a/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/autoinitialize/AutoInitializeProcessor.kt
+++ b/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/autoinitialize/AutoInitializeProcessor.kt
@@ -13,23 +13,8 @@ import se.ansman.dagger.auto.compiler.Errors
 import se.ansman.dagger.auto.compiler.autoinitialize.models.AutoInitializeModule
 import se.ansman.dagger.auto.compiler.autoinitialize.models.AutoInitializeObject
 import se.ansman.dagger.auto.compiler.common.Processor
-import se.ansman.dagger.auto.compiler.common.processing.AnnotationModel
-import se.ansman.dagger.auto.compiler.common.processing.AutoDaggerEnvironment
-import se.ansman.dagger.auto.compiler.common.processing.AutoDaggerResolver
-import se.ansman.dagger.auto.compiler.common.processing.ClassDeclaration
+import se.ansman.dagger.auto.compiler.common.processing.*
 import se.ansman.dagger.auto.compiler.common.processing.ClassDeclaration.Kind
-import se.ansman.dagger.auto.compiler.common.processing.ExecutableNode
-import se.ansman.dagger.auto.compiler.common.processing.Node
-import se.ansman.dagger.auto.compiler.common.processing.error
-import se.ansman.dagger.auto.compiler.common.processing.filterQualifiers
-import se.ansman.dagger.auto.compiler.common.processing.getAnnotation
-import se.ansman.dagger.auto.compiler.common.processing.getQualifiers
-import se.ansman.dagger.auto.compiler.common.processing.getValue
-import se.ansman.dagger.auto.compiler.common.processing.isAnnotatedWith
-import se.ansman.dagger.auto.compiler.common.processing.isAssignableTo
-import se.ansman.dagger.auto.compiler.common.processing.isFullyPublic
-import se.ansman.dagger.auto.compiler.common.processing.nodesAnnotatedWith
-import se.ansman.dagger.auto.compiler.common.processing.rootPeerClass
 import se.ansman.dagger.auto.compiler.common.rendering.HiltModuleBuilder
 import se.ansman.dagger.auto.compiler.common.rendering.Renderer
 import javax.inject.Scope
@@ -72,6 +57,7 @@ class AutoInitializeProcessor<N, TypeName, ClassName : TypeName, AnnotationSpec,
         for ((moduleKey, providers) in initializableObjectsByModule.asMap()) {
             val module = with(environment) {
                 AutoInitializeModule(
+                    processor = this@AutoInitializeProcessor.javaClass,
                     moduleName = rootPeerClass(
                         moduleKey.moduleName,
                         simpleNames(moduleKey.moduleName).joinToString(
@@ -101,6 +87,7 @@ class AutoInitializeProcessor<N, TypeName, ClassName : TypeName, AnnotationSpec,
             qualifiers = type.getQualifiers()
         )
         return AutoInitializeModule(
+            processor = this@AutoInitializeProcessor.javaClass,
             moduleName = obj.targetType.moduleName,
             installation = HiltModuleBuilder.Installation.InstallIn(className(SingletonComponent::class)),
             originatingTopLevelClassName = environment.topLevelClassName(type.className),

--- a/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/autoinitialize/models/AutoInitializeModule.kt
+++ b/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/autoinitialize/models/AutoInitializeModule.kt
@@ -1,9 +1,11 @@
 package se.ansman.dagger.auto.compiler.autoinitialize.models
 
+import se.ansman.dagger.auto.compiler.common.Processor
 import se.ansman.dagger.auto.compiler.common.models.HiltModule
 import se.ansman.dagger.auto.compiler.common.rendering.HiltModuleBuilder
 
 data class AutoInitializeModule<out Node, TypeName, ClassName : TypeName, AnnotationSpec>(
+    override val processor: Class<out Processor<*, *, *, *>>,
     override val moduleName: ClassName,
     override val installation: HiltModuleBuilder.Installation<ClassName>,
     override val originatingTopLevelClassName: ClassName,

--- a/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/optionallyprovided/OptionallyProvidedProcessor.kt
+++ b/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/optionallyprovided/OptionallyProvidedProcessor.kt
@@ -53,6 +53,7 @@ class OptionallyProvidedProcessor<N, TypeName : Any, ClassName : TypeName, Annot
         val component = getTargetComponent(this, resolver, annotation)
             ?: return null
         return OptionallyProvidedObjectModule(
+            processor = this@OptionallyProvidedProcessor.javaClass,
             moduleName = getModuleName(this, component),
             installation = HiltModuleBuilder.Installation.InstallIn(component),
             originatingTopLevelClassName = environment.topLevelClassName(className),

--- a/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/optionallyprovided/models/OptionallyProvidedObjectModule.kt
+++ b/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/optionallyprovided/models/OptionallyProvidedObjectModule.kt
@@ -1,9 +1,11 @@
 package se.ansman.dagger.auto.compiler.optionallyprovided.models
 
+import se.ansman.dagger.auto.compiler.common.Processor
 import se.ansman.dagger.auto.compiler.common.models.HiltModule
 import se.ansman.dagger.auto.compiler.common.rendering.HiltModuleBuilder
 
 data class OptionallyProvidedObjectModule<out Node, TypeName, ClassName : TypeName, AnnotationSpec>(
+    override val processor: Class<out Processor<*, *, *, *>>,
     override val moduleName: ClassName,
     override val installation: HiltModuleBuilder.Installation<ClassName>,
     override val originatingTopLevelClassName: ClassName,

--- a/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/replaces/ReplacesProcessor.kt
+++ b/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/replaces/ReplacesProcessor.kt
@@ -8,17 +8,8 @@ import se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor
 import se.ansman.dagger.auto.compiler.autobind.models.AutoBindObjectModule
 import se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor
 import se.ansman.dagger.auto.compiler.common.Processor
-import se.ansman.dagger.auto.compiler.common.processing.AutoDaggerEnvironment
-import se.ansman.dagger.auto.compiler.common.processing.AutoDaggerResolver
-import se.ansman.dagger.auto.compiler.common.processing.ClassDeclaration
+import se.ansman.dagger.auto.compiler.common.processing.*
 import se.ansman.dagger.auto.compiler.common.processing.ClassDeclaration.Kind
-import se.ansman.dagger.auto.compiler.common.processing.error
-import se.ansman.dagger.auto.compiler.common.processing.getAnnotation
-import se.ansman.dagger.auto.compiler.common.processing.getValue
-import se.ansman.dagger.auto.compiler.common.processing.isAnnotatedWith
-import se.ansman.dagger.auto.compiler.common.processing.isFullyPublic
-import se.ansman.dagger.auto.compiler.common.processing.nodesAnnotatedWith
-import se.ansman.dagger.auto.compiler.common.processing.rootPeerClass
 import se.ansman.dagger.auto.compiler.common.rendering.HiltModuleBuilder
 import se.ansman.dagger.auto.compiler.common.rendering.NoOpRenderer
 import se.ansman.dagger.auto.compiler.common.rendering.Renderer
@@ -101,6 +92,7 @@ class ReplacesProcessor<N, TypeName : Any, ClassName : TypeName, AnnotationSpec,
                 )
                 logger.info("Generating replacement for ${module.moduleName} named $moduleName")
                 AutoBindObjectModule(
+                    processor = javaClass,
                     moduleName = moduleName,
                     installation = HiltModuleBuilder.Installation.TestInstallIn(
                         components = module.installation.components,
@@ -129,6 +121,7 @@ class ReplacesProcessor<N, TypeName : Any, ClassName : TypeName, AnnotationSpec,
         logger.info("Rendering $moduleName")
         val file = renderer.render(
             AutoBindObjectModule(
+                processor = this@ReplacesProcessor.javaClass,
                 moduleName = moduleName,
                 installation = HiltModuleBuilder.Installation.TestInstallIn(
                     components = autoInitializeModule.installation.components,

--- a/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/retrofit/BaseApiServiceProcessor.kt
+++ b/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/retrofit/BaseApiServiceProcessor.kt
@@ -44,6 +44,7 @@ abstract class BaseApiServiceProcessor<N, TypeName, ClassName : TypeName, Annota
                 validateComponent(service, resolver, targetComponent)
 
                 ApiServiceModule(
+                    processor = javaClass,
                     moduleName = environment.rootPeerClass(
                         service.className,
                         environment.simpleNames(service.className).joinToString(

--- a/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/retrofit/models/ApiServiceModule.kt
+++ b/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/retrofit/models/ApiServiceModule.kt
@@ -1,9 +1,11 @@
 package se.ansman.dagger.auto.compiler.retrofit.models
 
+import se.ansman.dagger.auto.compiler.common.Processor
 import se.ansman.dagger.auto.compiler.common.models.HiltModule
 import se.ansman.dagger.auto.compiler.common.rendering.HiltModuleBuilder
 
 data class ApiServiceModule<out Node, ClassName, AnnotationSpec>(
+    override val processor: Class<out Processor<*, *, *, *>>,
     override val moduleName: ClassName,
     override val installation: HiltModuleBuilder.Installation<ClassName>,
     override val originatingTopLevelClassName: ClassName,

--- a/compiler/src/test/resources/tests/auto_bind/abstract_supertype/kapt/AutoBindRealRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/abstract_supertype/kapt/AutoBindRealRepositorySingletonModule.java.txt
@@ -7,7 +7,9 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import java.lang.String;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/abstract_supertype/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/abstract_supertype/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -6,8 +6,10 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 import kotlin.String
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/auto_bind/class_supertype/kapt/AutoBindRealRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/class_supertype/kapt/AutoBindRealRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/class_supertype/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/class_supertype/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/auto_bind/component_validation/kapt/AutoBindActivityRepositoryActivityModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/component_validation/kapt/AutoBindActivityRepositoryActivityModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.android.components.ActivityComponent;
 import dagger.hilt.codegen.OriginatingElement;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(ActivityComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/component_validation/kapt/AutoBindFragmentRepositoryFragmentModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/component_validation/kapt/AutoBindFragmentRepositoryFragmentModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.android.components.FragmentComponent;
 import dagger.hilt.codegen.OriginatingElement;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(FragmentComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/component_validation/kapt/AutoBindGlobalRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/component_validation/kapt/AutoBindGlobalRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/component_validation/ksp/AutoBindActivityRepositoryActivityModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/component_validation/ksp/AutoBindActivityRepositoryActivityModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityComponent
 import dagger.hilt.codegen.OriginatingElement
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(ActivityComponent::class)
 @OriginatingElement(topLevelClass = ActivityRepository::class)

--- a/compiler/src/test/resources/tests/auto_bind/component_validation/ksp/AutoBindFragmentRepositoryFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/component_validation/ksp/AutoBindFragmentRepositoryFragmentModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.FragmentComponent
 import dagger.hilt.codegen.OriginatingElement
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = FragmentRepository::class)

--- a/compiler/src/test/resources/tests/auto_bind/component_validation/ksp/AutoBindGlobalRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/component_validation/ksp/AutoBindGlobalRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = GlobalRepository::class)

--- a/compiler/src/test/resources/tests/auto_bind/custom_component/kapt/AutoBindRealRepositoryMyModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/custom_component/kapt/AutoBindRealRepositoryMyModule.java.txt
@@ -5,7 +5,9 @@ import dagger.Binds;
 import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(MyComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/custom_component/ksp/AutoBindRealRepositoryMyModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/custom_component/ksp/AutoBindRealRepositoryMyModule.kt.txt
@@ -5,7 +5,9 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(MyComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/auto_bind/fragment_scoped/kapt/AutoBindRealFragmentHelperFragmentModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/fragment_scoped/kapt/AutoBindRealFragmentHelperFragmentModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.android.components.FragmentComponent;
 import dagger.hilt.codegen.OriginatingElement;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(FragmentComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/fragment_scoped/ksp/AutoBindRealFragmentHelperFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/fragment_scoped/ksp/AutoBindRealFragmentHelperFragmentModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.FragmentComponent
 import dagger.hilt.codegen.OriginatingElement
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = RealFragmentHelper::class)

--- a/compiler/src/test/resources/tests/auto_bind/initializable/kapt/AutoBindRealRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/initializable/kapt/AutoBindRealRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/initializable/kapt/AutoInitializeRealRepositoryModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/initializable/kapt/AutoInitializeRealRepositoryModule.java.txt
@@ -7,8 +7,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/initializable/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/initializable/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/auto_bind/initializable/ksp/AutoInitializeRealRepositoryModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/initializable/ksp/AutoInitializeRealRepositoryModule.kt.txt
@@ -7,8 +7,10 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/auto_bind/internal/kapt/AutoBindRealRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/internal/kapt/AutoBindRealRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/internal/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/internal/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/auto_bind/into_map/kapt/AutoBindRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map/kapt/AutoBindRepositorySingletonModule.java.txt
@@ -9,7 +9,9 @@ import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoMap;
 import dagger.multibindings.StringKey;
 import java.io.Closeable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/into_map/ksp/AutoBindRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map/ksp/AutoBindRepositorySingletonModule.kt.txt
@@ -9,7 +9,9 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import java.io.Closeable
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Repository::class)

--- a/compiler/src/test/resources/tests/auto_bind/into_map_default/kapt/AutoBindSomeResourceSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map_default/kapt/AutoBindSomeResourceSingletonModule.java.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoMap;
 import dagger.multibindings.StringKey;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/into_map_default/ksp/AutoBindSomeResourceSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map_default/ksp/AutoBindSomeResourceSingletonModule.kt.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = SomeResource::class)

--- a/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/kapt/AutoBindBooleanProviderSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/kapt/AutoBindBooleanProviderSingletonModule.java.txt
@@ -9,7 +9,9 @@ import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
 import java.lang.Boolean;
 import java.util.concurrent.Callable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/kapt/AutoBindIntProviderSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/kapt/AutoBindIntProviderSingletonModule.java.txt
@@ -9,7 +9,9 @@ import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
 import java.lang.Integer;
 import java.util.concurrent.Callable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/kapt/AutoBindStringProviderSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/kapt/AutoBindStringProviderSingletonModule.java.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
 import java.util.concurrent.Callable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/ksp/AutoBindBooleanProviderSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/ksp/AutoBindBooleanProviderSingletonModule.kt.txt
@@ -8,8 +8,10 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import java.util.concurrent.Callable
+import javax.`annotation`.processing.Generated
 import kotlin.Boolean
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = BooleanProvider::class)

--- a/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/ksp/AutoBindIntProviderSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/ksp/AutoBindIntProviderSingletonModule.kt.txt
@@ -8,8 +8,10 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import java.util.concurrent.Callable
+import javax.`annotation`.processing.Generated
 import kotlin.Int
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = IntProvider::class)

--- a/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/ksp/AutoBindStringProviderSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/ksp/AutoBindStringProviderSingletonModule.kt.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import java.util.concurrent.Callable
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = StringProvider::class)

--- a/compiler/src/test/resources/tests/auto_bind/into_set/kapt/AutoBindRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set/kapt/AutoBindRepositorySingletonModule.java.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
 import java.io.Closeable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/into_set/ksp/AutoBindRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set/ksp/AutoBindRepositorySingletonModule.kt.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import java.io.Closeable
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Repository::class)

--- a/compiler/src/test/resources/tests/auto_bind/into_set_default/kapt/AutoBindSomeResourceSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_default/kapt/AutoBindSomeResourceSingletonModule.java.txt
@@ -7,7 +7,9 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/into_set_default/ksp/AutoBindSomeResourceSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_default/ksp/AutoBindSomeResourceSingletonModule.kt.txt
@@ -7,7 +7,9 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = SomeResource::class)

--- a/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/kapt/AutoBindBooleanProviderSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/kapt/AutoBindBooleanProviderSingletonModule.java.txt
@@ -9,7 +9,9 @@ import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
 import java.lang.Boolean;
 import java.util.concurrent.Callable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/kapt/AutoBindIntProviderSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/kapt/AutoBindIntProviderSingletonModule.java.txt
@@ -9,7 +9,9 @@ import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
 import java.lang.Integer;
 import java.util.concurrent.Callable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/kapt/AutoBindStringProviderSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/kapt/AutoBindStringProviderSingletonModule.java.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
 import java.util.concurrent.Callable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/ksp/AutoBindBooleanProviderSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/ksp/AutoBindBooleanProviderSingletonModule.kt.txt
@@ -8,8 +8,10 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import java.util.concurrent.Callable
+import javax.`annotation`.processing.Generated
 import kotlin.Boolean
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = BooleanProvider::class)

--- a/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/ksp/AutoBindIntProviderSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/ksp/AutoBindIntProviderSingletonModule.kt.txt
@@ -8,8 +8,10 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import java.util.concurrent.Callable
+import javax.`annotation`.processing.Generated
 import kotlin.Int
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = IntProvider::class)

--- a/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/ksp/AutoBindStringProviderSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/ksp/AutoBindStringProviderSingletonModule.kt.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import java.util.concurrent.Callable
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = StringProvider::class)

--- a/compiler/src/test/resources/tests/auto_bind/into_set_with_qualifier/kapt/AutoBindAuthInterceptorSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_with_qualifier/kapt/AutoBindAuthInterceptorSingletonModule.java.txt
@@ -7,8 +7,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import javax.inject.Named;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/into_set_with_qualifier/ksp/AutoBindAuthInterceptorSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_with_qualifier/ksp/AutoBindAuthInterceptorSingletonModule.kt.txt
@@ -7,8 +7,10 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import javax.inject.Named
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = AuthInterceptor::class)

--- a/compiler/src/test/resources/tests/auto_bind/lambda_supertype/kapt/AutoBindRunnableThingSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/lambda_supertype/kapt/AutoBindRunnableThingSingletonModule.java.txt
@@ -7,8 +7,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import java.lang.String;
+import javax.annotation.processing.Generated;
 import kotlin.jvm.functions.Function0;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/lambda_supertype/ksp/AutoBindRunnableThingSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/lambda_supertype/ksp/AutoBindRunnableThingSingletonModule.kt.txt
@@ -6,9 +6,11 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 import kotlin.Function0
 import kotlin.String
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RunnableThing::class)

--- a/compiler/src/test/resources/tests/auto_bind/multiple_binding_types/kapt/AutoBindRealTypeSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/multiple_binding_types/kapt/AutoBindRealTypeSingletonModule.java.txt
@@ -9,7 +9,9 @@ import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoMap;
 import dagger.multibindings.IntoSet;
 import dagger.multibindings.StringKey;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/multiple_binding_types/ksp/AutoBindRealTypeSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/multiple_binding_types/ksp/AutoBindRealTypeSingletonModule.kt.txt
@@ -9,7 +9,9 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.IntoSet
 import dagger.multibindings.StringKey
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealType::class)

--- a/compiler/src/test/resources/tests/auto_bind/multiple_types.filtered/kapt/AutoBindRealTypeSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/multiple_types.filtered/kapt/AutoBindRealTypeSingletonModule.java.txt
@@ -7,7 +7,9 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import java.lang.String;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/multiple_types.filtered/ksp/AutoBindRealTypeSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/multiple_types.filtered/ksp/AutoBindRealTypeSingletonModule.kt.txt
@@ -6,8 +6,10 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 import kotlin.String
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealType::class)

--- a/compiler/src/test/resources/tests/auto_bind/multiple_types/kapt/AutoBindRealTypeSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/multiple_types/kapt/AutoBindRealTypeSingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/multiple_types/ksp/AutoBindRealTypeSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/multiple_types/ksp/AutoBindRealTypeSingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealType::class)

--- a/compiler/src/test/resources/tests/auto_bind/object/kapt/AutoBindRealProviderSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/object/kapt/AutoBindRealProviderSingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Provides;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/object/ksp/AutoBindRealProviderSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/object/ksp/AutoBindRealProviderSingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealProvider::class)

--- a/compiler/src/test/resources/tests/auto_bind/reusable/kapt/AutoBindRealSomeUseCaseSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/reusable/kapt/AutoBindRealSomeUseCaseSingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/reusable/ksp/AutoBindRealSomeUseCaseSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/reusable/ksp/AutoBindRealSomeUseCaseSingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealSomeUseCase::class)

--- a/compiler/src/test/resources/tests/auto_bind/simple/kapt/AutoBindRealRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/simple/kapt/AutoBindRealRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/simple/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/simple/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/auto_bind/unscoped/kapt/AutoBindRealRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_bind/unscoped/kapt/AutoBindRealRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_bind/unscoped/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/unscoped/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/auto_initialize/binding.annotated/kapt/AutoInitializeBindingModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/binding.annotated/kapt/AutoInitializeBindingModule.java.txt
@@ -8,8 +8,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/binding.annotated/ksp/AutoInitializeBindingModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/binding.annotated/ksp/AutoInitializeBindingModule.kt.txt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = BindingModule::class)

--- a/compiler/src/test/resources/tests/auto_initialize/binding.qualified/kapt/AutoInitializeBindingModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/binding.qualified/kapt/AutoInitializeBindingModule.java.txt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import javax.inject.Named;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/binding.qualified/ksp/AutoInitializeBindingModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/binding.qualified/ksp/AutoInitializeBindingModule.kt.txt
@@ -8,10 +8,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import javax.inject.Named
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = BindingModule::class)

--- a/compiler/src/test/resources/tests/auto_initialize/binding/kapt/AutoInitializeBindingModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/binding/kapt/AutoInitializeBindingModule.java.txt
@@ -8,8 +8,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/binding/ksp/AutoInitializeBindingModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/binding/ksp/AutoInitializeBindingModule.kt.txt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = BindingModule::class)

--- a/compiler/src/test/resources/tests/auto_initialize/companion_object/kapt/AutoInitializeObjectModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/companion_object/kapt/AutoInitializeObjectModule.java.txt
@@ -9,8 +9,10 @@ import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
 import java.lang.Integer;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/companion_object/ksp/AutoInitializeObjectModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/companion_object/ksp/AutoInitializeObjectModule.kt.txt
@@ -8,10 +8,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import kotlin.Int
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = ObjectModule::class)

--- a/compiler/src/test/resources/tests/auto_initialize/initializable/kapt/AutoInitializeInitializableThingModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/initializable/kapt/AutoInitializeInitializableThingModule.java.txt
@@ -7,8 +7,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/initializable/ksp/AutoInitializeInitializableThingModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/initializable/ksp/AutoInitializeInitializableThingModule.kt.txt
@@ -7,8 +7,10 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = InitializableThing::class)

--- a/compiler/src/test/resources/tests/auto_initialize/internal_binding/kapt/AutoInitializeBindingModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/internal_binding/kapt/AutoInitializeBindingModule.java.txt
@@ -8,8 +8,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/internal_binding/ksp/AutoInitializeBindingModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/internal_binding/ksp/AutoInitializeBindingModule.kt.txt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = BindingModule::class)

--- a/compiler/src/test/resources/tests/auto_initialize/internal_object/kapt/AutoInitializeInternalObjectModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/internal_object/kapt/AutoInitializeInternalObjectModule.java.txt
@@ -8,8 +8,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/internal_object/ksp/AutoInitializeInternalObjectModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/internal_object/ksp/AutoInitializeInternalObjectModule.kt.txt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = InternalObject::class)

--- a/compiler/src/test/resources/tests/auto_initialize/nested/kapt/AutoInitializeOuterInnerModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/nested/kapt/AutoInitializeOuterInnerModule.java.txt
@@ -9,8 +9,10 @@ import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
 import java.lang.String;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/nested/kapt/AutoInitializeOuterSomeThingModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/nested/kapt/AutoInitializeOuterSomeThingModule.java.txt
@@ -8,8 +8,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/nested/ksp/AutoInitializeOuterInnerModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/nested/ksp/AutoInitializeOuterInnerModule.kt.txt
@@ -8,10 +8,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import kotlin.String
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Outer::class)

--- a/compiler/src/test/resources/tests/auto_initialize/nested/ksp/AutoInitializeOuterSomeThingModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/nested/ksp/AutoInitializeOuterSomeThingModule.kt.txt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Outer::class)

--- a/compiler/src/test/resources/tests/auto_initialize/non_initializable/kapt/AutoInitializeNonInitializableThingModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/non_initializable/kapt/AutoInitializeNonInitializableThingModule.java.txt
@@ -8,8 +8,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/non_initializable/ksp/AutoInitializeNonInitializableThingModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/non_initializable/ksp/AutoInitializeNonInitializableThingModule.kt.txt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = NonInitializableThing::class)

--- a/compiler/src/test/resources/tests/auto_initialize/priority.binding/kapt/AutoInitializeOuterSomeThingModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/priority.binding/kapt/AutoInitializeOuterSomeThingModule.java.txt
@@ -7,8 +7,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/priority.binding/ksp/AutoInitializeOuterSomeThingModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/priority.binding/ksp/AutoInitializeOuterSomeThingModule.kt.txt
@@ -7,9 +7,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.withPriority
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Outer::class)

--- a/compiler/src/test/resources/tests/auto_initialize/priority.provider/kapt/AutoInitializeOuterSomeThingModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/priority.provider/kapt/AutoInitializeOuterSomeThingModule.java.txt
@@ -8,8 +8,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/priority.provider/ksp/AutoInitializeOuterSomeThingModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/priority.provider/ksp/AutoInitializeOuterSomeThingModule.kt.txt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Outer::class)

--- a/compiler/src/test/resources/tests/auto_initialize/priority/kapt/AutoInitializeOuterSomeThingModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/priority/kapt/AutoInitializeOuterSomeThingModule.java.txt
@@ -8,8 +8,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/priority/ksp/AutoInitializeOuterSomeThingModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/priority/ksp/AutoInitializeOuterSomeThingModule.kt.txt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Outer::class)

--- a/compiler/src/test/resources/tests/auto_initialize/provider.qualified/kapt/AutoInitializeQualifiedProviderModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/provider.qualified/kapt/AutoInitializeQualifiedProviderModule.java.txt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import javax.inject.Named;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/provider.qualified/ksp/AutoInitializeQualifiedProviderModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/provider.qualified/ksp/AutoInitializeQualifiedProviderModule.kt.txt
@@ -8,10 +8,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import javax.inject.Named
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = QualifiedProviderModule::class)

--- a/compiler/src/test/resources/tests/auto_initialize/provider/kapt/AutoInitializeProviderModule.java.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/provider/kapt/AutoInitializeProviderModule.java.txt
@@ -8,8 +8,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/auto_initialize/provider/ksp/AutoInitializeProviderModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/provider/ksp/AutoInitializeProviderModule.kt.txt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = ProviderModule::class)

--- a/compiler/src/test/resources/tests/optionally_provided/custom_component/kapt/OptionallyProvidedRepositoryMyModule.java.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/custom_component/kapt/OptionallyProvidedRepositoryMyModule.java.txt
@@ -5,7 +5,9 @@ import dagger.BindsOptionalOf;
 import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.optionallyprovided.OptionallyProvidedProcessor")
 @Module
 @InstallIn(MyComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/optionally_provided/custom_component/ksp/OptionallyProvidedRepositoryMyModule.kt.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/custom_component/ksp/OptionallyProvidedRepositoryMyModule.kt.txt
@@ -5,7 +5,9 @@ import dagger.BindsOptionalOf
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.optionallyprovided.OptionallyProvidedProcessor")
 @Module
 @InstallIn(MyComponent::class)
 @OriginatingElement(topLevelClass = Repository::class)

--- a/compiler/src/test/resources/tests/optionally_provided/fragment_scoped/kapt/OptionallyProvidedFragmentHelperFragmentModule.java.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/fragment_scoped/kapt/OptionallyProvidedFragmentHelperFragmentModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.android.components.FragmentComponent;
 import dagger.hilt.codegen.OriginatingElement;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.optionallyprovided.OptionallyProvidedProcessor")
 @Module
 @InstallIn(FragmentComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/optionally_provided/fragment_scoped/ksp/OptionallyProvidedFragmentHelperFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/fragment_scoped/ksp/OptionallyProvidedFragmentHelperFragmentModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.FragmentComponent
 import dagger.hilt.codegen.OriginatingElement
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.optionallyprovided.OptionallyProvidedProcessor")
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = FragmentHelper::class)

--- a/compiler/src/test/resources/tests/optionally_provided/internal/kapt/OptionallyProvidedRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/internal/kapt/OptionallyProvidedRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.optionallyprovided.OptionallyProvidedProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/optionally_provided/internal/ksp/OptionallyProvidedRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/internal/ksp/OptionallyProvidedRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.optionallyprovided.OptionallyProvidedProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Repository::class)

--- a/compiler/src/test/resources/tests/optionally_provided/qualified/kapt/OptionallyProvidedApiSingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/qualified/kapt/OptionallyProvidedApiSingletonModule.java.txt
@@ -6,8 +6,10 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 import javax.inject.Named;
 
+@Generated("se.ansman.dagger.auto.compiler.optionallyprovided.OptionallyProvidedProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/optionally_provided/qualified/ksp/OptionallyProvidedApiSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/qualified/ksp/OptionallyProvidedApiSingletonModule.kt.txt
@@ -6,8 +6,10 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 import javax.inject.Named
 
+@Generated("se.ansman.dagger.auto.compiler.optionallyprovided.OptionallyProvidedProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Api::class)

--- a/compiler/src/test/resources/tests/optionally_provided/unscoped/kapt/OptionallyProvidedRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/unscoped/kapt/OptionallyProvidedRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.optionallyprovided.OptionallyProvidedProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/optionally_provided/unscoped/ksp/OptionallyProvidedRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/unscoped/ksp/OptionallyProvidedRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.optionallyprovided.OptionallyProvidedProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Repository::class)

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/kapt/AutoBindFakeRepositoryFragmentModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/kapt/AutoBindFakeRepositoryFragmentModule.java.txt
@@ -9,7 +9,9 @@ import dagger.hilt.testing.TestInstallIn;
 import dagger.multibindings.IntoMap;
 import dagger.multibindings.StringKey;
 import java.lang.Runnable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
     components = FragmentComponent.class,

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/kapt/AutoBindFakeRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/kapt/AutoBindFakeRepositorySingletonModule.java.txt
@@ -8,7 +8,9 @@ import dagger.hilt.components.SingletonComponent;
 import dagger.hilt.testing.TestInstallIn;
 import dagger.multibindings.IntoSet;
 import java.io.Closeable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
     components = SingletonComponent.class,

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/kapt/AutoBindRealRepositoryFragmentModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/kapt/AutoBindRealRepositoryFragmentModule.java.txt
@@ -9,7 +9,9 @@ import dagger.hilt.codegen.OriginatingElement;
 import dagger.multibindings.IntoMap;
 import dagger.multibindings.StringKey;
 import java.lang.Runnable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(FragmentComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/kapt/AutoBindRealRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/kapt/AutoBindRealRepositorySingletonModule.java.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
 import java.io.Closeable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindFakeRepositoryFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindFakeRepositoryFragmentModule.kt.txt
@@ -9,7 +9,9 @@ import dagger.hilt.testing.TestInstallIn
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import java.lang.Runnable
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
   components = [FragmentComponent::class],

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
@@ -8,7 +8,9 @@ import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
 import dagger.multibindings.IntoSet
 import java.io.Closeable
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
   components = [SingletonComponent::class],

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindRealRepositoryFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindRealRepositoryFragmentModule.kt.txt
@@ -9,7 +9,9 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import java.lang.Runnable
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import java.io.Closeable
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/kapt/AutoBindFakeRepositoryFragmentModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/kapt/AutoBindFakeRepositoryFragmentModule.java.txt
@@ -5,7 +5,9 @@ import dagger.Module;
 import dagger.hilt.android.components.FragmentComponent;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.testing.TestInstallIn;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
     components = FragmentComponent.class,

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/kapt/AutoBindFakeRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/kapt/AutoBindFakeRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.hilt.testing.TestInstallIn;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
     components = SingletonComponent.class,

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/kapt/AutoBindRealRepositoryFragmentModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/kapt/AutoBindRealRepositoryFragmentModule.java.txt
@@ -10,7 +10,9 @@ import dagger.multibindings.IntoMap;
 import dagger.multibindings.StringKey;
 import java.lang.String;
 import java.util.concurrent.Callable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(FragmentComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/kapt/AutoBindRealRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/kapt/AutoBindRealRepositorySingletonModule.java.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
 import java.util.concurrent.Callable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindFakeRepositoryFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindFakeRepositoryFragmentModule.kt.txt
@@ -5,7 +5,9 @@ import dagger.Module
 import dagger.hilt.android.components.FragmentComponent
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.testing.TestInstallIn
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
   components = [FragmentComponent::class],

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
   components = [SingletonComponent::class],

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindRealRepositoryFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindRealRepositoryFragmentModule.kt.txt
@@ -9,8 +9,10 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import java.util.concurrent.Callable
+import javax.`annotation`.processing.Generated
 import kotlin.String
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import java.util.concurrent.Callable
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/replaces/auto_bind/kapt/AutoBindFakeRepositoryFragmentModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind/kapt/AutoBindFakeRepositoryFragmentModule.java.txt
@@ -5,7 +5,9 @@ import dagger.Module;
 import dagger.hilt.android.components.FragmentComponent;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.testing.TestInstallIn;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
     components = FragmentComponent.class,

--- a/compiler/src/test/resources/tests/replaces/auto_bind/kapt/AutoBindFakeRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind/kapt/AutoBindFakeRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.hilt.testing.TestInstallIn;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
     components = SingletonComponent.class,

--- a/compiler/src/test/resources/tests/replaces/auto_bind/kapt/AutoBindRealRepositoryFragmentModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind/kapt/AutoBindRealRepositoryFragmentModule.java.txt
@@ -9,7 +9,9 @@ import dagger.hilt.codegen.OriginatingElement;
 import dagger.multibindings.IntoMap;
 import dagger.multibindings.StringKey;
 import java.lang.Runnable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(FragmentComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/replaces/auto_bind/kapt/AutoBindRealRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind/kapt/AutoBindRealRepositorySingletonModule.java.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
 import java.io.Closeable;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindFakeRepositoryFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindFakeRepositoryFragmentModule.kt.txt
@@ -5,7 +5,9 @@ import dagger.Module
 import dagger.hilt.android.components.FragmentComponent
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.testing.TestInstallIn
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
   components = [FragmentComponent::class],

--- a/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
   components = [SingletonComponent::class],

--- a/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindRealRepositoryFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindRealRepositoryFragmentModule.kt.txt
@@ -9,7 +9,9 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import java.lang.Runnable
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -8,7 +8,9 @@ import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import java.io.Closeable
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/replaces/initializable/kapt/AutoBindFakeRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/initializable/kapt/AutoBindFakeRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.hilt.testing.TestInstallIn;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
     components = SingletonComponent.class,

--- a/compiler/src/test/resources/tests/replaces/initializable/kapt/AutoBindRealRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/initializable/kapt/AutoBindRealRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/replaces/initializable/kapt/AutoInitializeRealRepositoryModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/initializable/kapt/AutoInitializeRealRepositoryModule.java.txt
@@ -8,8 +8,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/replaces/initializable/kapt/FakeRepositoryAutoInitializeReplacementModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/initializable/kapt/FakeRepositoryAutoInitializeReplacementModule.java.txt
@@ -5,7 +5,9 @@ import dagger.Module;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.hilt.testing.TestInstallIn;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
     components = SingletonComponent.class,

--- a/compiler/src/test/resources/tests/replaces/initializable/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/initializable/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
   components = [SingletonComponent::class],

--- a/compiler/src/test/resources/tests/replaces/initializable/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/initializable/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/replaces/initializable/ksp/AutoInitializeRealRepositoryModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/initializable/ksp/AutoInitializeRealRepositoryModule.kt.txt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/replaces/initializable/ksp/FakeRepositoryAutoInitializeReplacementModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/initializable/ksp/FakeRepositoryAutoInitializeReplacementModule.kt.txt
@@ -5,7 +5,9 @@ import dagger.Module
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
   components = [SingletonComponent::class],

--- a/compiler/src/test/resources/tests/replaces/object/kapt/AutoBindFakeRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/object/kapt/AutoBindFakeRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Provides;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.hilt.testing.TestInstallIn;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
     components = SingletonComponent.class,

--- a/compiler/src/test/resources/tests/replaces/object/kapt/AutoBindRealRepositorySingletonModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/object/kapt/AutoBindRealRepositorySingletonModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Module;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/replaces/object/kapt/AutoInitializeRealRepositoryModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/object/kapt/AutoInitializeRealRepositoryModule.java.txt
@@ -8,8 +8,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
+import javax.annotation.processing.Generated;
 import se.ansman.dagger.auto.Initializable;
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/compiler/src/test/resources/tests/replaces/object/kapt/FakeRepositoryAutoInitializeReplacementModule.java.txt
+++ b/compiler/src/test/resources/tests/replaces/object/kapt/FakeRepositoryAutoInitializeReplacementModule.java.txt
@@ -5,7 +5,9 @@ import dagger.Module;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import dagger.hilt.testing.TestInstallIn;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
     components = SingletonComponent.class,

--- a/compiler/src/test/resources/tests/replaces/object/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/object/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Provides
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
   components = [SingletonComponent::class],

--- a/compiler/src/test/resources/tests/replaces/object/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/object/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/replaces/object/ksp/AutoInitializeRealRepositoryModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/object/ksp/AutoInitializeRealRepositoryModule.kt.txt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import javax.`annotation`.processing.Generated
 import se.ansman.dagger.auto.Initializable
 import se.ansman.dagger.auto.Initializable.Companion.asInitializable
 
+@Generated("se.ansman.dagger.auto.compiler.autoinitialize.AutoInitializeProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)

--- a/compiler/src/test/resources/tests/replaces/object/ksp/FakeRepositoryAutoInitializeReplacementModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/object/ksp/FakeRepositoryAutoInitializeReplacementModule.kt.txt
@@ -5,7 +5,9 @@ import dagger.Module
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.replaces.ReplacesProcessor")
 @Module
 @TestInstallIn(
   components = [SingletonComponent::class],

--- a/gradle-plugin/src/main/kotlin/se/ansman/dagger/auto/gradle/ResourceTests.kt
+++ b/gradle-plugin/src/main/kotlin/se/ansman/dagger/auto/gradle/ResourceTests.kt
@@ -4,19 +4,42 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.getValue
 import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.registering
 
 fun Project.setupResourceTests() {
-    val updateExpectedTestFiles by tasks.registering {
-        dependsOn("cleanProcessTestResources")
-        dependsOn("test")
+    val updateExpectedTestFiles by tasks.registering
+    pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+        updateExpectedTestFiles.configure {
+            dependsOn("cleanProcessTestResources")
+            dependsOn("test")
+        }
     }
-    gradle.taskGraph.whenReady {
-        if (hasTask("$path:${updateExpectedTestFiles.name}")) {
-            tasks.named<Test>("test") {
-                systemProperty("writeExpectedFilesTo", file("src/test/resources/tests"))
+    pluginManager.withPlugin("com.android.library") {
+        updateExpectedTestFiles.configure {
+            dependsOn("cleanProcessDebugUnitTestResources")
+            dependsOn("testDebugUnitTest")
+        }
+    }
+    afterEvaluate {
+        val testTask = when {
+            pluginManager.hasPlugin("org.jetbrains.kotlin.jvm") -> tasks.named<Test>("test")
+
+            pluginManager.hasPlugin("com.android.library") -> tasks.named<Test>("testDebugUnitTest")
+
+            else -> error("Unknown project")
+        }
+        val writeExpectedFiles = objects.property<Boolean>()
+        testTask.configure {
+            inputs.property("writeExpectedFiles", writeExpectedFiles)
+            systemProperty("writeExpectedFilesTo", project.file("src/test/resources/tests"))
+            doFirst {
+                systemProperty("writeExpectedFiles", writeExpectedFiles.get())
             }
+        }
+        gradle.taskGraph.whenReady {
+            writeExpectedFiles.set(hasTask("$path:${updateExpectedTestFiles.name}"))
         }
     }
 }

--- a/third-party/androidx/room/src/test/resources/tests/androidx_room/duplicate_accessors/kapt/AutoDaggerAppDatabaseModule.java.txt
+++ b/third-party/androidx/room/src/test/resources/tests/androidx_room/duplicate_accessors/kapt/AutoDaggerAppDatabaseModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Provides;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.androidx.room.AndroidXRoomProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/androidx/room/src/test/resources/tests/androidx_room/duplicate_accessors/ksp/AutoDaggerAppDatabaseModule.kt.txt
+++ b/third-party/androidx/room/src/test/resources/tests/androidx_room/duplicate_accessors/ksp/AutoDaggerAppDatabaseModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.androidx.room.AndroidXRoomProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = AppDatabase::class)

--- a/third-party/androidx/room/src/test/resources/tests/androidx_room/functions/kapt/AutoDaggerAppDatabaseModule.java.txt
+++ b/third-party/androidx/room/src/test/resources/tests/androidx_room/functions/kapt/AutoDaggerAppDatabaseModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Provides;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.androidx.room.AndroidXRoomProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/androidx/room/src/test/resources/tests/androidx_room/functions/ksp/AutoDaggerAppDatabaseModule.kt.txt
+++ b/third-party/androidx/room/src/test/resources/tests/androidx_room/functions/ksp/AutoDaggerAppDatabaseModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.androidx.room.AndroidXRoomProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = AppDatabase::class)

--- a/third-party/androidx/room/src/test/resources/tests/androidx_room/properties/kapt/AutoDaggerAppDatabaseModule.java.txt
+++ b/third-party/androidx/room/src/test/resources/tests/androidx_room/properties/kapt/AutoDaggerAppDatabaseModule.java.txt
@@ -6,7 +6,9 @@ import dagger.Provides;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.androidx.room.AndroidXRoomProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/androidx/room/src/test/resources/tests/androidx_room/properties/ksp/AutoDaggerAppDatabaseModule.kt.txt
+++ b/third-party/androidx/room/src/test/resources/tests/androidx_room/properties/ksp/AutoDaggerAppDatabaseModule.kt.txt
@@ -6,7 +6,9 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.androidx.room.AndroidXRoomProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = AppDatabase::class)

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/custom_component/kapt/AutoBindKtorfitApiService.java.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/custom_component/kapt/AutoBindKtorfitApiService.java.txt
@@ -7,7 +7,9 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.android.components.FragmentComponent;
 import dagger.hilt.codegen.OriginatingElement;
 import de.jensklingenberg.ktorfit.Ktorfit;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(FragmentComponent.class)
 @OriginatingElement(

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/custom_component/ksp/AutoBindKtorfitApiService.kt.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/custom_component/ksp/AutoBindKtorfitApiService.kt.txt
@@ -7,7 +7,9 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.components.FragmentComponent
 import dagger.hilt.codegen.OriginatingElement
 import de.jensklingenberg.ktorfit.Ktorfit
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = ApiService::class)

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/non_public/kapt/AutoBindKtorfitApiService.java.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/non_public/kapt/AutoBindKtorfitApiService.java.txt
@@ -7,7 +7,9 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import de.jensklingenberg.ktorfit.Ktorfit;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/non_public/ksp/AutoBindKtorfitApiService.kt.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/non_public/ksp/AutoBindKtorfitApiService.kt.txt
@@ -7,7 +7,9 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import de.jensklingenberg.ktorfit.Ktorfit
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = ApiService::class)

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/non_public_parent/kapt/AutoBindKtorfitWrapper1Wrapper2ApiService.java.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/non_public_parent/kapt/AutoBindKtorfitWrapper1Wrapper2ApiService.java.txt
@@ -7,7 +7,9 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import de.jensklingenberg.ktorfit.Ktorfit;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/non_public_parent/ksp/AutoBindKtorfitWrapper1Wrapper2ApiService.kt.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/non_public_parent/ksp/AutoBindKtorfitWrapper1Wrapper2ApiService.kt.txt
@@ -7,7 +7,9 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import de.jensklingenberg.ktorfit.Ktorfit
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Wrapper1::class)

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/qualifiers/kapt/AutoBindKtorfitApiService.java.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/qualifiers/kapt/AutoBindKtorfitApiService.java.txt
@@ -7,8 +7,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import de.jensklingenberg.ktorfit.Ktorfit;
+import javax.annotation.processing.Generated;
 import javax.inject.Named;
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/qualifiers/ksp/AutoBindKtorfitApiService.kt.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/qualifiers/ksp/AutoBindKtorfitApiService.kt.txt
@@ -7,8 +7,10 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import de.jensklingenberg.ktorfit.Ktorfit
+import javax.`annotation`.processing.Generated
 import javax.inject.Named
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = ApiService::class)

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/reusable/kapt/AutoBindKtorfitApiService.java.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/reusable/kapt/AutoBindKtorfitApiService.java.txt
@@ -8,7 +8,9 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import de.jensklingenberg.ktorfit.Ktorfit;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/reusable/ksp/AutoBindKtorfitApiService.kt.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/reusable/ksp/AutoBindKtorfitApiService.kt.txt
@@ -8,7 +8,9 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import de.jensklingenberg.ktorfit.Ktorfit
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = ApiService::class)

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/scoped/kapt/AutoBindKtorfitApiService.java.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/scoped/kapt/AutoBindKtorfitApiService.java.txt
@@ -7,8 +7,10 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import de.jensklingenberg.ktorfit.Ktorfit;
+import javax.annotation.processing.Generated;
 import javax.inject.Singleton;
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/scoped/ksp/AutoBindKtorfitApiService.kt.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/scoped/ksp/AutoBindKtorfitApiService.kt.txt
@@ -7,8 +7,10 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import de.jensklingenberg.ktorfit.Ktorfit
+import javax.`annotation`.processing.Generated
 import javax.inject.Singleton
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = ApiService::class)

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/simple/kapt/AutoBindKtorfitApiService.java.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/simple/kapt/AutoBindKtorfitApiService.java.txt
@@ -7,7 +7,9 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
 import de.jensklingenberg.ktorfit.Ktorfit;
+import javax.annotation.processing.Generated;
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/ktorfit/src/test/resources/tests/ktorfit/simple/ksp/AutoBindKtorfitApiService.kt.txt
+++ b/third-party/ktorfit/src/test/resources/tests/ktorfit/simple/ksp/AutoBindKtorfitApiService.kt.txt
@@ -7,7 +7,9 @@ import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
 import de.jensklingenberg.ktorfit.Ktorfit
+import javax.`annotation`.processing.Generated
 
+@Generated("se.ansman.dagger.auto.compiler.ktorfit.KtorfitProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = ApiService::class)

--- a/third-party/retrofit/src/test/resources/tests/retrofit/custom_component/kapt/AutoBindRetrofitApiService.java.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/custom_component/kapt/AutoBindRetrofitApiService.java.txt
@@ -6,8 +6,10 @@ import dagger.Provides;
 import dagger.hilt.InstallIn;
 import dagger.hilt.android.components.FragmentComponent;
 import dagger.hilt.codegen.OriginatingElement;
+import javax.annotation.processing.Generated;
 import retrofit2.Retrofit;
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(FragmentComponent.class)
 @OriginatingElement(

--- a/third-party/retrofit/src/test/resources/tests/retrofit/custom_component/ksp/AutoBindRetrofitApiService.kt.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/custom_component/ksp/AutoBindRetrofitApiService.kt.txt
@@ -6,9 +6,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.FragmentComponent
 import dagger.hilt.codegen.OriginatingElement
+import javax.`annotation`.processing.Generated
 import retrofit2.Retrofit
 import retrofit2.create
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = ApiService::class)

--- a/third-party/retrofit/src/test/resources/tests/retrofit/non_public/kapt/AutoBindRetrofitApiService.java.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/non_public/kapt/AutoBindRetrofitApiService.java.txt
@@ -6,8 +6,10 @@ import dagger.Provides;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 import retrofit2.Retrofit;
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/retrofit/src/test/resources/tests/retrofit/non_public/ksp/AutoBindRetrofitApiService.kt.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/non_public/ksp/AutoBindRetrofitApiService.kt.txt
@@ -6,9 +6,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 import retrofit2.Retrofit
 import retrofit2.create
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = ApiService::class)

--- a/third-party/retrofit/src/test/resources/tests/retrofit/non_public_parent/kapt/AutoBindRetrofitWrapper1Wrapper2ApiService.java.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/non_public_parent/kapt/AutoBindRetrofitWrapper1Wrapper2ApiService.java.txt
@@ -6,8 +6,10 @@ import dagger.Provides;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 import retrofit2.Retrofit;
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/retrofit/src/test/resources/tests/retrofit/non_public_parent/ksp/AutoBindRetrofitWrapper1Wrapper2ApiService.kt.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/non_public_parent/ksp/AutoBindRetrofitWrapper1Wrapper2ApiService.kt.txt
@@ -6,9 +6,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 import retrofit2.Retrofit
 import retrofit2.create
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Wrapper1::class)

--- a/third-party/retrofit/src/test/resources/tests/retrofit/qualifiers/kapt/AutoBindRetrofitApiService.java.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/qualifiers/kapt/AutoBindRetrofitApiService.java.txt
@@ -6,9 +6,11 @@ import dagger.Provides;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 import javax.inject.Named;
 import retrofit2.Retrofit;
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/retrofit/src/test/resources/tests/retrofit/qualifiers/ksp/AutoBindRetrofitApiService.kt.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/qualifiers/ksp/AutoBindRetrofitApiService.kt.txt
@@ -6,10 +6,12 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 import javax.inject.Named
 import retrofit2.Retrofit
 import retrofit2.create
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = ApiService::class)

--- a/third-party/retrofit/src/test/resources/tests/retrofit/reusable/kapt/AutoBindRetrofitApiService.java.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/reusable/kapt/AutoBindRetrofitApiService.java.txt
@@ -7,8 +7,10 @@ import dagger.Reusable;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 import retrofit2.Retrofit;
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/retrofit/src/test/resources/tests/retrofit/reusable/ksp/AutoBindRetrofitApiService.kt.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/reusable/ksp/AutoBindRetrofitApiService.kt.txt
@@ -7,9 +7,11 @@ import dagger.Reusable
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 import retrofit2.Retrofit
 import retrofit2.create
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = ApiService::class)

--- a/third-party/retrofit/src/test/resources/tests/retrofit/scoped/kapt/AutoBindRetrofitApiService.java.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/scoped/kapt/AutoBindRetrofitApiService.java.txt
@@ -6,9 +6,11 @@ import dagger.Provides;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 import javax.inject.Singleton;
 import retrofit2.Retrofit;
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/retrofit/src/test/resources/tests/retrofit/scoped/ksp/AutoBindRetrofitApiService.kt.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/scoped/ksp/AutoBindRetrofitApiService.kt.txt
@@ -6,10 +6,12 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 import javax.inject.Singleton
 import retrofit2.Retrofit
 import retrofit2.create
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = ApiService::class)

--- a/third-party/retrofit/src/test/resources/tests/retrofit/simple/kapt/AutoBindRetrofitApiService.java.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/simple/kapt/AutoBindRetrofitApiService.java.txt
@@ -6,8 +6,10 @@ import dagger.Provides;
 import dagger.hilt.InstallIn;
 import dagger.hilt.codegen.OriginatingElement;
 import dagger.hilt.components.SingletonComponent;
+import javax.annotation.processing.Generated;
 import retrofit2.Retrofit;
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(SingletonComponent.class)
 @OriginatingElement(

--- a/third-party/retrofit/src/test/resources/tests/retrofit/simple/ksp/AutoBindRetrofitApiService.kt.txt
+++ b/third-party/retrofit/src/test/resources/tests/retrofit/simple/ksp/AutoBindRetrofitApiService.kt.txt
@@ -6,9 +6,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.codegen.OriginatingElement
 import dagger.hilt.components.SingletonComponent
+import javax.`annotation`.processing.Generated
 import retrofit2.Retrofit
 import retrofit2.create
 
+@Generated("se.ansman.dagger.auto.compiler.retrofit.RetrofitProcessor")
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = ApiService::class)


### PR DESCRIPTION
This will match what Dagger does and allows excluding the generated sources from public APIs etc.

This fixes #221, sort of