### PR TITLE
[codex] Harden GitHub workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -15,19 +18,19 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
       with:
         distribution: 'zulu'
         java-version: '23'
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.13'
 
     - name: Run Checks
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
       with:
         arguments: check --continue --stacktrace --scan
 
@@ -36,15 +39,15 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: checks
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
       with:
         distribution: 'zulu'
         java-version: '21'
 
     - name: Deploy Snapshot
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
       with:
         arguments: publishSnapshot --no-configuration-cache --stacktrace
       env:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,19 +17,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: 'zulu'
           java-version: '23'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
       - name: Publish Docs
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
         env:
           GRGIT_USER: x-access-token
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Harden the repository GitHub Actions workflows against mutable third-party action refs and overly broad default token permissions.

## Changes

- Add explicit least-privilege `contents: read` permissions to the Gradle workflow.
- Keep the docs publishing workflow scoped to `contents: write`, which it needs for publication.
- Pin all referenced GitHub Actions to full commit SHAs, with the original version tags preserved as comments for readability.

## Validation

- Parsed `.github/workflows/gradle.yml` and `.github/workflows/pages.yml` as YAML.
- Searched `.github/workflows` for `pull_request_target`, `id-token`, `actions/cache`, and remaining mutable action refs such as `@vN`, `@main`, or `@master`; none were found.