### PR TITLE
Fix generated Hilt module constructors

### DIFF
--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -32,7 +32,9 @@ dependencies {
 
     testFixturesApi(libs.bundles.jvmTesting)
     testFixturesApi(libs.dagger)
+    testFixturesApi(libs.dagger.compiler)
     testFixturesApi(libs.dagger.hilt.core)
+    testFixturesApi(libs.dagger.hilt.compiler)
     testFixturesApi(libs.bundles.compileTesting)
     testFixturesApi(projects.compiler.common)
 }

--- a/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/ksp/HiltKotlinModuleBuilder.kt
+++ b/compiler/src/main/kotlin/se/ansman/dagger/auto/compiler/ksp/HiltKotlinModuleBuilder.kt
@@ -122,7 +122,6 @@ class HiltKotlinModuleBuilder private constructor(
             bindings.isNotEmpty() ->
                 TypeSpec.classBuilder(info.moduleName)
                     .addModifiers(KModifier.ABSTRACT)
-                    .primaryConstructor(FunSpec.constructorBuilder().addModifiers(KModifier.PRIVATE).build())
                     .addFunctions(bindings)
                     .applyIf(providers.isNotEmpty()) {
                         addType(

--- a/compiler/src/test/kotlin/se/ansman/dagger/auto/compiler/HiltRootValidationTest.kt
+++ b/compiler/src/test/kotlin/se/ansman/dagger/auto/compiler/HiltRootValidationTest.kt
@@ -1,0 +1,195 @@
+package se.ansman.dagger.auto.compiler
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import dagger.hilt.processor.internal.root.ComponentTreeDepsProcessor
+import dagger.internal.codegen.ComponentProcessor
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.io.OutputStream
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCompilerApi::class)
+class HiltRootValidationTest {
+    @TempDir
+    lateinit var tempDirectory: File
+
+    @Test
+    fun `generated AutoBind module with default constructor passes Hilt root module validation`() {
+        val result = KotlinCompilation()
+            .apply {
+                workingDir = tempDirectory
+                inheritClassPath = true
+                messageOutputStream = OutputStream.nullOutputStream()
+                sources = hiltRootSources() + generatedAutoBindModule()
+                annotationProcessors = listOf(ComponentTreeDepsProcessor(), ComponentProcessor())
+                kaptArgs = mutableMapOf("dagger.hilt.internal.useAggregatingRootProcessor" to "true")
+            }
+            .compile()
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+    }
+
+    private fun hiltRootSources(): List<SourceFile> =
+        listOf(
+            SourceFile.kotlin(
+                name = "Application.kt",
+                contents = """
+                package android.app
+
+                open class Application
+                """
+            ),
+            SourceFile.kotlin(
+                name = "HiltAndroidApp.kt",
+                contents = """
+                package dagger.hilt.android
+
+                import kotlin.reflect.KClass
+
+                @Target(AnnotationTarget.CLASS)
+                @Retention(AnnotationRetention.RUNTIME)
+                annotation class HiltAndroidApp(val value: KClass<*> = Void::class)
+                """
+            ),
+            SourceFile.kotlin(
+                name = "AggregatedRoot.kt",
+                contents = """
+                package dagger.hilt.internal.aggregatedroot
+
+                import kotlin.reflect.KClass
+
+                @Target(AnnotationTarget.CLASS)
+                @Retention(AnnotationRetention.BINARY)
+                annotation class AggregatedRoot(
+                    val root: String,
+                    val rootPackage: String,
+                    val rootSimpleNames: Array<String>,
+                    val originatingRoot: String,
+                    val originatingRootPackage: String,
+                    val originatingRootSimpleNames: Array<String>,
+                    val rootAnnotation: KClass<*>,
+                    val rootComponentPackage: String = "",
+                    val rootComponentSimpleNames: Array<String> = [],
+                )
+                """
+            ),
+            SourceFile.kotlin(
+                name = "ComponentTreeDeps.kt",
+                contents = """
+                package dagger.hilt.internal.componenttreedeps
+
+                import kotlin.reflect.KClass
+
+                @Target(AnnotationTarget.CLASS)
+                @Retention(AnnotationRetention.BINARY)
+                annotation class ComponentTreeDeps(
+                    val rootDeps: Array<KClass<*>> = [],
+                    val defineComponentDeps: Array<KClass<*>> = [],
+                    val aliasOfDeps: Array<KClass<*>> = [],
+                    val aggregatedDeps: Array<KClass<*>> = [],
+                    val uninstallModulesDeps: Array<KClass<*>> = [],
+                    val earlyEntryPointDeps: Array<KClass<*>> = [],
+                )
+                """
+            ),
+            SourceFile.kotlin(
+                name = "TestApplication.kt",
+                contents = """
+                package se.ansman
+
+                @dagger.hilt.android.HiltAndroidApp(Hilt_TestApplication::class)
+                class TestApplication : Hilt_TestApplication()
+
+                open class Hilt_TestApplication : android.app.Application()
+
+                interface RecordHandler<Result, Command>
+
+                class CreateRecord {
+                    class Result
+                }
+
+                class CreateRecordHandler @javax.inject.Inject constructor() :
+                    RecordHandler<CreateRecord.Result, CreateRecord>
+                """
+            ),
+            SourceFile.java(
+                name = "AggregatedRootMetadata.java",
+                contents = """
+                package dagger.hilt.internal.aggregatedroot;
+
+                @AggregatedRoot(
+                    root = "se.ansman.TestApplication",
+                    rootPackage = "se.ansman",
+                    rootSimpleNames = "TestApplication",
+                    originatingRoot = "se.ansman.TestApplication",
+                    originatingRootPackage = "se.ansman",
+                    originatingRootSimpleNames = "TestApplication",
+                    rootAnnotation = dagger.hilt.android.HiltAndroidApp.class,
+                    rootComponentPackage = "dagger.hilt.components",
+                    rootComponentSimpleNames = "SingletonComponent"
+                )
+                public final class AggregatedRootMetadata {}
+                """
+            ),
+            SourceFile.java(
+                name = "AggregatedDepsMetadata.java",
+                contents = """
+                package hilt_aggregated_deps;
+
+                @dagger.hilt.processor.internal.aggregateddeps.AggregatedDeps(
+                    components = "dagger.hilt.components.SingletonComponent",
+                    modules = "se.ansman.AutoBindCreateRecordHandlerSingletonModule"
+                )
+                public final class AggregatedDepsMetadata {}
+                """
+            ),
+            SourceFile.java(
+                name = "TestApplication_ComponentTreeDeps.java",
+                contents = """
+                package se.ansman;
+
+                @dagger.hilt.internal.componenttreedeps.ComponentTreeDeps(
+                    rootDeps = dagger.hilt.internal.aggregatedroot.AggregatedRootMetadata.class,
+                    defineComponentDeps =
+                        dagger.hilt.processor.internal.definecomponent.codegen._dagger_hilt_components_SingletonComponent.class,
+                    aggregatedDeps = hilt_aggregated_deps.AggregatedDepsMetadata.class
+                )
+                public final class TestApplication_ComponentTreeDeps {}
+                """
+            )
+        )
+
+    private fun generatedAutoBindModule(): SourceFile =
+        SourceFile.kotlin(
+            name = "AutoBindCreateRecordHandlerSingletonModule.kt",
+            contents = """
+            // Code generated by Auto Dagger. Do not edit.
+            package se.ansman
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.codegen.OriginatingElement
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.ClassKey
+            import dagger.multibindings.IntoMap
+            import javax.annotation.processing.Generated
+
+            @Generated("se.ansman.dagger.auto.compiler.autobind.AutoBindProcessor")
+            @Module
+            @InstallIn(SingletonComponent::class)
+            @OriginatingElement(topLevelClass = CreateRecordHandler::class)
+            public abstract class AutoBindCreateRecordHandlerSingletonModule {
+                @Binds
+                @IntoMap
+                @ClassKey(CreateRecord::class)
+                public abstract fun bindCreateRecordHandlerAsRecordHandlerIntoMap(
+                    createRecordHandler: CreateRecordHandler
+                ): RecordHandler<CreateRecord.Result, CreateRecord>
+            }
+            """
+        )
+}

--- a/compiler/src/test/resources/tests/auto_bind/abstract_supertype/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/abstract_supertype/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -13,7 +13,7 @@ import kotlin.String
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositorySingletonModule private constructor() {
+public abstract class AutoBindRealRepositorySingletonModule {
   @Binds
   public abstract fun bindRealRepositoryAsRepositoryOfString(realRepository: RealRepository): Repository<String>
 }

--- a/compiler/src/test/resources/tests/auto_bind/class_supertype/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/class_supertype/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositorySingletonModule private constructor() {
+public abstract class AutoBindRealRepositorySingletonModule {
   @Binds
   public abstract fun bindRealRepositoryAsRepository(realRepository: RealRepository): Repository
 }

--- a/compiler/src/test/resources/tests/auto_bind/component_validation/ksp/AutoBindActivityRepositoryActivityModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/component_validation/ksp/AutoBindActivityRepositoryActivityModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(ActivityComponent::class)
 @OriginatingElement(topLevelClass = ActivityRepository::class)
-public abstract class AutoBindActivityRepositoryActivityModule private constructor() {
+public abstract class AutoBindActivityRepositoryActivityModule {
   @Binds
   public abstract fun bindActivityRepositoryAsRepository(activityRepository: ActivityRepository): Repository
 }

--- a/compiler/src/test/resources/tests/auto_bind/component_validation/ksp/AutoBindFragmentRepositoryFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/component_validation/ksp/AutoBindFragmentRepositoryFragmentModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = FragmentRepository::class)
-public abstract class AutoBindFragmentRepositoryFragmentModule private constructor() {
+public abstract class AutoBindFragmentRepositoryFragmentModule {
   @Binds
   public abstract fun bindFragmentRepositoryAsRepository(fragmentRepository: FragmentRepository): Repository
 }

--- a/compiler/src/test/resources/tests/auto_bind/component_validation/ksp/AutoBindGlobalRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/component_validation/ksp/AutoBindGlobalRepositorySingletonModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = GlobalRepository::class)
-public abstract class AutoBindGlobalRepositorySingletonModule private constructor() {
+public abstract class AutoBindGlobalRepositorySingletonModule {
   @Binds
   public abstract fun bindGlobalRepositoryAsRepository(globalRepository: GlobalRepository): Repository
 }

--- a/compiler/src/test/resources/tests/auto_bind/custom_component/ksp/AutoBindRealRepositoryMyModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/custom_component/ksp/AutoBindRealRepositoryMyModule.kt.txt
@@ -11,7 +11,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(MyComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositoryMyModule private constructor() {
+public abstract class AutoBindRealRepositoryMyModule {
   @Binds
   public abstract fun bindRealRepositoryAsRepository(realRepository: RealRepository): Repository
 }

--- a/compiler/src/test/resources/tests/auto_bind/fragment_scoped/ksp/AutoBindRealFragmentHelperFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/fragment_scoped/ksp/AutoBindRealFragmentHelperFragmentModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = RealFragmentHelper::class)
-public abstract class AutoBindRealFragmentHelperFragmentModule private constructor() {
+public abstract class AutoBindRealFragmentHelperFragmentModule {
   @Binds
   public abstract fun bindRealFragmentHelperAsFragmentHelper(realFragmentHelper: RealFragmentHelper): FragmentHelper
 }

--- a/compiler/src/test/resources/tests/auto_bind/initializable/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/initializable/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositorySingletonModule private constructor() {
+public abstract class AutoBindRealRepositorySingletonModule {
   @Binds
   public abstract fun bindRealRepositoryAsRepository(realRepository: RealRepository): Repository
 }

--- a/compiler/src/test/resources/tests/auto_bind/initializable/ksp/AutoInitializeRealRepositoryModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/initializable/ksp/AutoInitializeRealRepositoryModule.kt.txt
@@ -14,7 +14,7 @@ import se.ansman.dagger.auto.Initializable
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoInitializeRealRepositoryModule private constructor() {
+public abstract class AutoInitializeRealRepositoryModule {
   @Binds
   @IntoSet
   public abstract fun bindRealRepositoryAsInitializable(realRepository: RealRepository): Initializable

--- a/compiler/src/test/resources/tests/auto_bind/internal/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/internal/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositorySingletonModule private constructor() {
+public abstract class AutoBindRealRepositorySingletonModule {
   @Binds
   internal abstract fun bindRealRepositoryAsRepository(realRepository: RealRepository): Repository
 }

--- a/compiler/src/test/resources/tests/auto_bind/into_map/ksp/AutoBindRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map/ksp/AutoBindRepositorySingletonModule.kt.txt
@@ -15,7 +15,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Repository::class)
-public abstract class AutoBindRepositorySingletonModule private constructor() {
+public abstract class AutoBindRepositorySingletonModule {
   @Binds
   @IntoMap
   @StringKey(`value` = "test")

--- a/compiler/src/test/resources/tests/auto_bind/into_map_default/ksp/AutoBindSomeResourceSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map_default/ksp/AutoBindSomeResourceSingletonModule.kt.txt
@@ -14,7 +14,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = SomeResource::class)
-public abstract class AutoBindSomeResourceSingletonModule private constructor() {
+public abstract class AutoBindSomeResourceSingletonModule {
   @Binds
   @IntoMap
   @StringKey(`value` = "test")

--- a/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/ksp/AutoBindBooleanProviderSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/ksp/AutoBindBooleanProviderSingletonModule.kt.txt
@@ -15,7 +15,7 @@ import kotlin.Boolean
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = BooleanProvider::class)
-public abstract class AutoBindBooleanProviderSingletonModule private constructor() {
+public abstract class AutoBindBooleanProviderSingletonModule {
   @Binds
   @IntoSet
   public abstract fun bindBooleanProviderAsCallableOfBooleanIntoSet(booleanProvider: BooleanProvider): Callable<Boolean>

--- a/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/ksp/AutoBindIntProviderSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/ksp/AutoBindIntProviderSingletonModule.kt.txt
@@ -15,7 +15,7 @@ import kotlin.Int
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = IntProvider::class)
-public abstract class AutoBindIntProviderSingletonModule private constructor() {
+public abstract class AutoBindIntProviderSingletonModule {
   @Binds
   @IntoSet
   public abstract fun bindIntProviderAsCallableOfIntIntoSet(intProvider: IntProvider): Callable<Int>

--- a/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/ksp/AutoBindStringProviderSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_map_wildcard/ksp/AutoBindStringProviderSingletonModule.kt.txt
@@ -14,7 +14,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = StringProvider::class)
-public abstract class AutoBindStringProviderSingletonModule private constructor() {
+public abstract class AutoBindStringProviderSingletonModule {
   @Binds
   @IntoSet
   public abstract fun bindStringProviderAsCallableOfStarIntoSet(stringProvider: StringProvider): Callable<*>

--- a/compiler/src/test/resources/tests/auto_bind/into_set/ksp/AutoBindRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set/ksp/AutoBindRepositorySingletonModule.kt.txt
@@ -14,7 +14,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Repository::class)
-public abstract class AutoBindRepositorySingletonModule private constructor() {
+public abstract class AutoBindRepositorySingletonModule {
   @Binds
   @IntoSet
   public abstract fun bindRepositoryAsCloseableIntoSet(repository: Repository): Closeable

--- a/compiler/src/test/resources/tests/auto_bind/into_set_default/ksp/AutoBindSomeResourceSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_default/ksp/AutoBindSomeResourceSingletonModule.kt.txt
@@ -13,7 +13,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = SomeResource::class)
-public abstract class AutoBindSomeResourceSingletonModule private constructor() {
+public abstract class AutoBindSomeResourceSingletonModule {
   @Binds
   @IntoSet
   public abstract fun bindSomeResourceAsResourceOfStarIntoSet(someResource: SomeResource): Resource<*>

--- a/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/ksp/AutoBindBooleanProviderSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/ksp/AutoBindBooleanProviderSingletonModule.kt.txt
@@ -15,7 +15,7 @@ import kotlin.Boolean
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = BooleanProvider::class)
-public abstract class AutoBindBooleanProviderSingletonModule private constructor() {
+public abstract class AutoBindBooleanProviderSingletonModule {
   @Binds
   @IntoSet
   public abstract fun bindBooleanProviderAsCallableOfBooleanIntoSet(booleanProvider: BooleanProvider): Callable<Boolean>

--- a/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/ksp/AutoBindIntProviderSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/ksp/AutoBindIntProviderSingletonModule.kt.txt
@@ -15,7 +15,7 @@ import kotlin.Int
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = IntProvider::class)
-public abstract class AutoBindIntProviderSingletonModule private constructor() {
+public abstract class AutoBindIntProviderSingletonModule {
   @Binds
   @IntoSet
   public abstract fun bindIntProviderAsCallableOfIntIntoSet(intProvider: IntProvider): Callable<Int>

--- a/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/ksp/AutoBindStringProviderSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_wildcard/ksp/AutoBindStringProviderSingletonModule.kt.txt
@@ -14,7 +14,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = StringProvider::class)
-public abstract class AutoBindStringProviderSingletonModule private constructor() {
+public abstract class AutoBindStringProviderSingletonModule {
   @Binds
   @IntoSet
   public abstract fun bindStringProviderAsCallableOfStarIntoSet(stringProvider: StringProvider): Callable<*>

--- a/compiler/src/test/resources/tests/auto_bind/into_set_with_qualifier/ksp/AutoBindAuthInterceptorSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_with_qualifier/ksp/AutoBindAuthInterceptorSingletonModule.kt.txt
@@ -14,7 +14,7 @@ import javax.inject.Named
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = AuthInterceptor::class)
-public abstract class AutoBindAuthInterceptorSingletonModule private constructor() {
+public abstract class AutoBindAuthInterceptorSingletonModule {
   @Binds
   @IntoSet
   @Named(`value` = "api")

--- a/compiler/src/test/resources/tests/auto_bind/into_set_with_qualifier_2/ksp/AutoBindShortcutLifecycleTaskSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/into_set_with_qualifier_2/ksp/AutoBindShortcutLifecycleTaskSingletonModule.kt.txt
@@ -15,7 +15,7 @@ import tests.auto_bind.into_set_with_qualifier_2.lifecycle.di.LifecycleTask
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = ShortcutLifecycleTask::class)
-public abstract class AutoBindShortcutLifecycleTaskSingletonModule private constructor() {
+public abstract class AutoBindShortcutLifecycleTaskSingletonModule {
   @Binds
   @IntoSet
   @LifecycleTask(lifecycleStep = AppLifecycleTask.LifecycleStep.AppForegrounded)

--- a/compiler/src/test/resources/tests/auto_bind/lambda_supertype/ksp/AutoBindRunnableThingSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/lambda_supertype/ksp/AutoBindRunnableThingSingletonModule.kt.txt
@@ -14,7 +14,7 @@ import kotlin.String
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RunnableThing::class)
-public abstract class AutoBindRunnableThingSingletonModule private constructor() {
+public abstract class AutoBindRunnableThingSingletonModule {
   @Binds
   public abstract fun bindRunnableThingAsFunction0OfString(runnableThing: RunnableThing): Function0<String>
 }

--- a/compiler/src/test/resources/tests/auto_bind/multiple_binding_types/ksp/AutoBindRealTypeSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/multiple_binding_types/ksp/AutoBindRealTypeSingletonModule.kt.txt
@@ -15,7 +15,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealType::class)
-public abstract class AutoBindRealTypeSingletonModule private constructor() {
+public abstract class AutoBindRealTypeSingletonModule {
   @Binds
   public abstract fun bindRealTypeAsType1(realType: RealType): Type1
 

--- a/compiler/src/test/resources/tests/auto_bind/multiple_types.filtered/ksp/AutoBindRealTypeSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/multiple_types.filtered/ksp/AutoBindRealTypeSingletonModule.kt.txt
@@ -13,7 +13,7 @@ import kotlin.String
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealType::class)
-public abstract class AutoBindRealTypeSingletonModule private constructor() {
+public abstract class AutoBindRealTypeSingletonModule {
   @Binds
   public abstract fun bindRealTypeAsType2OfString(realType: RealType): Type2<String>
 }

--- a/compiler/src/test/resources/tests/auto_bind/multiple_types/ksp/AutoBindRealTypeSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/multiple_types/ksp/AutoBindRealTypeSingletonModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealType::class)
-public abstract class AutoBindRealTypeSingletonModule private constructor() {
+public abstract class AutoBindRealTypeSingletonModule {
   @Binds
   public abstract fun bindRealTypeAsType1(realType: RealType): Type1
 

--- a/compiler/src/test/resources/tests/auto_bind/reusable/ksp/AutoBindRealSomeUseCaseSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/reusable/ksp/AutoBindRealSomeUseCaseSingletonModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealSomeUseCase::class)
-public abstract class AutoBindRealSomeUseCaseSingletonModule private constructor() {
+public abstract class AutoBindRealSomeUseCaseSingletonModule {
   @Binds
   public abstract fun bindRealSomeUseCaseAsSomeUseCase(realSomeUseCase: RealSomeUseCase): SomeUseCase
 }

--- a/compiler/src/test/resources/tests/auto_bind/simple/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/simple/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositorySingletonModule private constructor() {
+public abstract class AutoBindRealRepositorySingletonModule {
   @Binds
   public abstract fun bindRealRepositoryAsRepository(realRepository: RealRepository): Repository
 }

--- a/compiler/src/test/resources/tests/auto_bind/unscoped/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_bind/unscoped/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositorySingletonModule private constructor() {
+public abstract class AutoBindRealRepositorySingletonModule {
   @Binds
   public abstract fun bindRealRepositoryAsRepository(realRepository: RealRepository): Repository
 }

--- a/compiler/src/test/resources/tests/auto_initialize/initializable/ksp/AutoInitializeInitializableThingModule.kt.txt
+++ b/compiler/src/test/resources/tests/auto_initialize/initializable/ksp/AutoInitializeInitializableThingModule.kt.txt
@@ -14,7 +14,7 @@ import se.ansman.dagger.auto.Initializable
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = InitializableThing::class)
-public abstract class AutoInitializeInitializableThingModule private constructor() {
+public abstract class AutoInitializeInitializableThingModule {
   @Binds
   @IntoSet
   public abstract fun bindInitializableThingAsInitializable(initializableThing: InitializableThing): Initializable

--- a/compiler/src/test/resources/tests/optionally_provided/custom_component/ksp/OptionallyProvidedRepositoryMyModule.kt.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/custom_component/ksp/OptionallyProvidedRepositoryMyModule.kt.txt
@@ -11,7 +11,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(MyComponent::class)
 @OriginatingElement(topLevelClass = Repository::class)
-public abstract class OptionallyProvidedRepositoryMyModule private constructor() {
+public abstract class OptionallyProvidedRepositoryMyModule {
   @BindsOptionalOf
   public abstract fun bindsOptionalRepository(): Repository
 }

--- a/compiler/src/test/resources/tests/optionally_provided/fragment_scoped/ksp/OptionallyProvidedFragmentHelperFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/fragment_scoped/ksp/OptionallyProvidedFragmentHelperFragmentModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = FragmentHelper::class)
-public abstract class OptionallyProvidedFragmentHelperFragmentModule private constructor() {
+public abstract class OptionallyProvidedFragmentHelperFragmentModule {
   @BindsOptionalOf
   public abstract fun bindsOptionalFragmentHelper(): FragmentHelper
 }

--- a/compiler/src/test/resources/tests/optionally_provided/internal/ksp/OptionallyProvidedRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/internal/ksp/OptionallyProvidedRepositorySingletonModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Repository::class)
-public abstract class OptionallyProvidedRepositorySingletonModule private constructor() {
+public abstract class OptionallyProvidedRepositorySingletonModule {
   @BindsOptionalOf
   public abstract fun bindsOptionalRepository(): Repository
 }

--- a/compiler/src/test/resources/tests/optionally_provided/qualified/ksp/OptionallyProvidedApiSingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/qualified/ksp/OptionallyProvidedApiSingletonModule.kt.txt
@@ -13,7 +13,7 @@ import javax.inject.Named
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Api::class)
-public abstract class OptionallyProvidedApiSingletonModule private constructor() {
+public abstract class OptionallyProvidedApiSingletonModule {
   @BindsOptionalOf
   @Named(`value` = "Dev")
   public abstract fun bindsOptionalApi(): Api

--- a/compiler/src/test/resources/tests/optionally_provided/unscoped/ksp/OptionallyProvidedRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/optionally_provided/unscoped/ksp/OptionallyProvidedRepositorySingletonModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = Repository::class)
-public abstract class OptionallyProvidedRepositorySingletonModule private constructor() {
+public abstract class OptionallyProvidedRepositorySingletonModule {
   @BindsOptionalOf
   public abstract fun bindsOptionalRepository(): Repository
 }

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindFakeRepositoryFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindFakeRepositoryFragmentModule.kt.txt
@@ -18,7 +18,7 @@ import javax.`annotation`.processing.Generated
   replaces = [AutoBindRealRepositoryFragmentModule::class],
 )
 @OriginatingElement(topLevelClass = FakeRepository::class)
-public abstract class AutoBindFakeRepositoryFragmentModule private constructor() {
+public abstract class AutoBindFakeRepositoryFragmentModule {
   @Binds
   @IntoMap
   @StringKey(`value` = "repository")

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
@@ -17,7 +17,7 @@ import javax.`annotation`.processing.Generated
   replaces = [AutoBindRealRepositorySingletonModule::class],
 )
 @OriginatingElement(topLevelClass = FakeRepository::class)
-public abstract class AutoBindFakeRepositorySingletonModule private constructor() {
+public abstract class AutoBindFakeRepositorySingletonModule {
   @Binds
   public abstract fun bindFakeRepositoryAsRepository(fakeRepository: FakeRepository): Repository
 

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindRealRepositoryFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindRealRepositoryFragmentModule.kt.txt
@@ -15,7 +15,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositoryFragmentModule private constructor() {
+public abstract class AutoBindRealRepositoryFragmentModule {
   @Binds
   @IntoMap
   @StringKey(`value` = "repository")

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_multibinds/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -14,7 +14,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositorySingletonModule private constructor() {
+public abstract class AutoBindRealRepositorySingletonModule {
   @Binds
   public abstract fun bindRealRepositoryAsRepository(realRepository: RealRepository): Repository
 

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
@@ -15,7 +15,7 @@ import javax.`annotation`.processing.Generated
   replaces = [AutoBindRealRepositorySingletonModule::class],
 )
 @OriginatingElement(topLevelClass = FakeRepository::class)
-public abstract class AutoBindFakeRepositorySingletonModule private constructor() {
+public abstract class AutoBindFakeRepositorySingletonModule {
   @Binds
   public abstract fun bindFakeRepositoryAsRepository(fakeRepository: FakeRepository): Repository
 }

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindRealRepositoryFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindRealRepositoryFragmentModule.kt.txt
@@ -16,7 +16,7 @@ import kotlin.String
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositoryFragmentModule private constructor() {
+public abstract class AutoBindRealRepositoryFragmentModule {
   @Binds
   @IntoMap
   @StringKey(`value` = "repository")

--- a/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind.with_wildcard/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -14,7 +14,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositorySingletonModule private constructor() {
+public abstract class AutoBindRealRepositorySingletonModule {
   @Binds
   public abstract fun bindRealRepositoryAsRepository(realRepository: RealRepository): Repository
 

--- a/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
@@ -15,7 +15,7 @@ import javax.`annotation`.processing.Generated
   replaces = [AutoBindRealRepositorySingletonModule::class],
 )
 @OriginatingElement(topLevelClass = FakeRepository::class)
-public abstract class AutoBindFakeRepositorySingletonModule private constructor() {
+public abstract class AutoBindFakeRepositorySingletonModule {
   @Binds
   public abstract fun bindFakeRepositoryAsRepository(fakeRepository: FakeRepository): Repository
 }

--- a/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindRealRepositoryFragmentModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindRealRepositoryFragmentModule.kt.txt
@@ -15,7 +15,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(FragmentComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositoryFragmentModule private constructor() {
+public abstract class AutoBindRealRepositoryFragmentModule {
   @Binds
   @IntoMap
   @StringKey(`value` = "repository")

--- a/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/auto_bind/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -14,7 +14,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositorySingletonModule private constructor() {
+public abstract class AutoBindRealRepositorySingletonModule {
   @Binds
   public abstract fun bindRealRepositoryAsRepository(realRepository: RealRepository): Repository
 

--- a/compiler/src/test/resources/tests/replaces/initializable/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/initializable/ksp/AutoBindFakeRepositorySingletonModule.kt.txt
@@ -15,7 +15,7 @@ import javax.`annotation`.processing.Generated
   replaces = [AutoBindRealRepositorySingletonModule::class],
 )
 @OriginatingElement(topLevelClass = FakeRepository::class)
-public abstract class AutoBindFakeRepositorySingletonModule private constructor() {
+public abstract class AutoBindFakeRepositorySingletonModule {
   @Binds
   public abstract fun bindFakeRepositoryAsRepository(fakeRepository: FakeRepository): Repository
 }

--- a/compiler/src/test/resources/tests/replaces/initializable/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/initializable/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositorySingletonModule private constructor() {
+public abstract class AutoBindRealRepositorySingletonModule {
   @Binds
   public abstract fun bindRealRepositoryAsRepository(realRepository: RealRepository): Repository
 }

--- a/compiler/src/test/resources/tests/replaces/object/ksp/AutoBindRealRepositorySingletonModule.kt.txt
+++ b/compiler/src/test/resources/tests/replaces/object/ksp/AutoBindRealRepositorySingletonModule.kt.txt
@@ -12,7 +12,7 @@ import javax.`annotation`.processing.Generated
 @Module
 @InstallIn(SingletonComponent::class)
 @OriginatingElement(topLevelClass = RealRepository::class)
-public abstract class AutoBindRealRepositorySingletonModule private constructor() {
+public abstract class AutoBindRealRepositorySingletonModule {
   @Binds
   public abstract fun bindRealRepositoryAsRepository(realRepository: RealRepository): Repository
 }


### PR DESCRIPTION
## Summary
- Stop generating private constructors for abstract Hilt modules that contain binding methods
- Add a focused Hilt root validation regression test for the generated AutoBind module shape
- Update generated source fixtures to reflect the public no-arg constructor shape

This fixes #481

## Validation
- ./gradlew :compiler:test