### PR TITLE
[codex] Fix Vanniktech sources jar publishing config

### DIFF
--- a/build-logic/src/main/kotlin/library.publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/library.publishing.gradle.kts
@@ -103,7 +103,7 @@ pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
         configure(
             KotlinJvm(
                 javadocJar = JavadocJar.Dokka(tasks.dokkaGeneratePublicationJavadoc.name),
-                sourcesJar = true
+                sourcesJar = SourcesJar.Sources()
             )
         )
     }


### PR DESCRIPTION
## Summary

Updates the JVM publishing convention to use Vanniktech's `SourcesJar.Sources()` option instead of the deprecated boolean `sourcesJar = true` constructor argument.

## Why

Gradle emitted a deprecation warning from `library.publishing.gradle.kts` because `KotlinJvm(javadocJar, sourcesJar: Boolean)` has been deprecated in favor of the overload that accepts a `SourcesJar` value.

## Validation

- `./gradlew help --warning-mode=all`